### PR TITLE
Support forward/back mouse buttons.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -305,6 +305,10 @@ app.on("ready", () => {
     mainWindow.on("closed", () => {
         app.exit(0)
     })
+    mainWindow.on("app-command", (e, cmd) => {
+        mainWindow.webContents.send("app-command", cmd)
+        e.preventDefault()
+    })
     // Load app and send urls when ready
     mainWindow.loadURL(`file://${path.join(__dirname, "index.html")}`)
     mainWindow.webContents.once("did-finish-load", () => {

--- a/app/js/input.js
+++ b/app/js/input.js
@@ -317,6 +317,15 @@ const init = () => {
             executeMapString("<A-F4>", true, true)
         }
     })
+    ipcRenderer.on("app-command", (_, cmd) => {
+        if (SETTINGS.get("mouse")) {
+            if (cmd === "browser-backward") {
+                ACTIONS.backInHistory()
+            } else if (cmd === "browser-forward") {
+                ACTIONS.forwardInHistory()
+            }
+        }
+    })
     setInterval(() => ACTIONS.setFocusCorrectly(), 500)
     ACTIONS.setFocusCorrectly()
     const unSupportedActions = [


### PR DESCRIPTION
In electron, back/forward mouse button events are translated to ["app commands"](https://www.electronjs.org/docs/api/browser-window#event-app-command-windows-linux).

Maybe these should be mappable via `map` and co., but I wasn't sure whether that's the right approach.