### PR TITLE
Prevent size changes when switching between splits.

### DIFF
--- a/app/css/index.css
+++ b/app/css/index.css
@@ -45,7 +45,8 @@ img {height: 1.5em;width: 1.5em;min-height: 1.5em;min-width: 1.5em;pointer-event
 #tabs.wrap .spacer {display: inline-block;}
 /* pages */
 #page-container, #current-page, .visible-page {display: flex;flex: 1;height: 100%;width: 100%;}
-#pages.multiple #current-page {border: solid .15em #f90;box-sizing: border-box;}
+#pages.multiple webview {border: solid .15em #333;box-sizing: border-box;}
+#pages.multiple #current-page {border-color: #f90;}
 webview {pointer-events: none;position: fixed;display: none;}
 #pagelayout {display: flex;height: 100%;width: 100%;}
 #pagelayout * {flex: 1;}


### PR DESCRIPTION
If you switched between two pages in a split, then the contents of the pages shifted annoyingly by a few pixels.

This commit changes the CSS so that the border is always enabled and only the border color is changes (thus preventing any changes in layout).