### PR TITLE
Several changes for a nix package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The releases of Vieb aim to follow [semantic versioning](https://semver.org).
 - Mouse back/forward buttons being ignored when the mouse setting is enabled
 - Modifiers being ignored when pressing certain named keys such as "Space"
 - Border of split pages moving the page slightly when switching (border is now always there but in gray)
+- Updating the adblocker files when Vieb is installed on a read-only file system
 
 ### Deprecated
 

--- a/app/index.js
+++ b/app/index.js
@@ -131,9 +131,13 @@ const useragent = () => session.defaultSession.getUserAgent()
     .replace(RegExp(`${app.getName()}/\\S* `), "")
 
 // Parse arguments
-let args = process.argv.slice(1)
-if (args[0] === "app" || args[0] === app.getAppPath()) {
-    args = args.slice(1)
+let args
+if (process.defaultApp) {
+    // argv is ["electron", "app", ...args]
+    args = process.argv.slice(2)
+} else {
+    // argv is ["vieb", ...args]
+    args = process.argv.slice(1)
 }
 const urls = []
 let enableDebugMode = false

--- a/app/js/sessions.js
+++ b/app/js/sessions.js
@@ -54,9 +54,12 @@ const enableAdblocker = () => {
         for (const name of Object.keys(defaultBlocklists)) {
             const list = path.join(__dirname, `../blocklists/${name}.txt`)
             try {
-                fs.copyFileSync(list, path.join(blocklistDir, `${name}.txt`))
+                // File is read and written separately to discard permission
+                const body = fs.readFileSync(list)
+                fs.writeFileSync(path.join(blocklistDir, `${name}.txt`), body)
             } catch (e) {
-                UTIL.notify(`Failed to copy ${name}`, "err")
+                const msg = e.message || e
+                UTIL.notify(`Failed to copy ${name}:\n${msg}`, "err")
             }
         }
     }
@@ -72,15 +75,16 @@ const enableAdblocker = () => {
                             path.join(blocklistDir, `${list}.txt`), body)
                         ipcRenderer.send("adblock-enable")
                     } catch (e) {
-                        UTIL.notify(`Failed to update ${list}`, "err")
+                        const msg = e.message || e
+                        UTIL.notify(`Failed to update ${list}:\n${msg}`, "err")
                     }
                 })
                 res.on("data", chunk => {
                     body += chunk
                 })
             })
-            req.on("error", () => {
-                UTIL.notify(`Failed to update ${list}`, "err")
+            req.on("error", e => {
+                UTIL.notify(`Failed to update ${list}:\n${e.message}`, "err")
             })
             req.end()
         }


### PR DESCRIPTION
I want to package vieb for [nixos](https://nixos.org).

The `electron-builder` tool does not work on nixos, so I'm calling the electron executable directly with the installed vieb app directory as argument.  For some reason, the current check did not reliably support this usage.  I have hence changed this part to use the `process.defaultApp` flag as described here: https://github.com/electron/electron/issues/4690#issuecomment-217435222

Furthermore, applications are installed read-only (with mode 0444 and modification time set to Jan 1, 1970).  The current adblocking code uses `fs.copyFileSync`, which unhelpfully preserves this read-only permission.  If you start vieb again, it fails because it cannot overwrite the now read-only blocklists in the config directory.  I have also added the error message to the failure notification.