### PR TITLE
Do not save favicons with error status code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The releases of Vieb aim to follow [semantic versioning](https://semver.org).
 - Modifiers being ignored when pressing certain named keys such as "Space"
 - Border of split pages moving the page slightly when switching (border is now always there but in gray)
 - Updating the adblocker files when Vieb is installed on a read-only file system
+- Favicons being accepted even though the HTTP status code was an error (such as 404)
 
 ### Deprecated
 

--- a/app/index.js
+++ b/app/index.js
@@ -858,6 +858,10 @@ ipcMain.on("download-favicon", (_, fav, location, webId, linkId, url) => {
     request.on("response", res => {
         const data = []
         res.on("end", () => {
+            if (res.statusCode !== 200) {
+                // Failed to download favicon
+                return
+            }
             const file = Buffer.concat(data)
             if (isSvg(file)) {
                 location += ".svg"


### PR DESCRIPTION
Sine websites don't have favicons (last one I ran into was https://nyxt.atlas.engineer) and you get a 404 response for the favicon.  In this case Vieb used to save an empty file, resulting in a "broken image" icon for the favicon.

There's still something strange going on with that site because the spinner does not disappear.