### PR TITLE
Allow vertical scrolling to move the tabs list horizontally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The releases of Vieb aim to follow [semantic versioning](https://semver.org).
 - Multiple tabs of the same special page can now be opened using the commands, as some of them are container specific
 - The startup argument "--portable" has been replaced with "--datafolder", use "--datafolder ./ViebData" for old functionality
 - Erwic now uses the "datafolder" startup argument instead of a JSON field for the datafolder location configuration
+- Tab list can now be scrolled horizontally using the mouse wheel
 
 ### Fixed
 

--- a/app/js/tabs.js
+++ b/app/js/tabs.js
@@ -35,6 +35,13 @@ const init = () => {
         if (UTIL.appIcon()) {
             document.getElementById("logo").src = UTIL.appIcon()
         }
+
+        // Allow vertical scrolling to move the tabs list horizontally
+        document.getElementById("tabs").addEventListener("wheel", e => {
+            document.getElementById("tabs").scrollBy(e.deltaX + e.deltaY, 0)
+            e.preventDefault()
+        })
+
         const parsed = UTIL.readJSON(tabFile)
         if (!erwicMode) {
             if (parsed) {


### PR DESCRIPTION
In mouse mode, you can now scroll up/down on the tab list to move it left/right.  (Scrolling left/right also moves the tab list as before, but that's not a comfortable scrolling direction on many mice.)