### PR TITLE
Add yank and download actions in follow mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The releases of Vieb aim to follow [semantic versioning](https://semver.org).
 - Special container names to open tabs externally, in tabs with a matching domain, or use the same container as the current tab
 - Support for SVG favicons by giving it an explicit ".svg" extension if detected by "is-svg"
 - Devtools that can be opened as a split window or in a separate tab, in addition to the existing windowed developer tools
+- Added "pointer.downloadLink" action that downloads the hovered link in pointer mode
 
 ### Changed
 

--- a/app/js/input.js
+++ b/app/js/input.js
@@ -153,6 +153,7 @@ const defaultBindings = {
         "]": {"mapping": "<pointer.scrollDown>"},
         "b": {"mapping": "<pointer.moveFastLeft>"},
         "d": {"mapping": "<pointer.downloadImage>"},
+        "D": {"mapping": "<pointer.downloadLink>"},
         "<C-d>": {"mapping": "<pointer.moveFastDown>"},
         "e": {"mapping": "<pointer.inspectElement>"},
         "f": {"mapping": "<action.startFollowCurrentTab>"},

--- a/app/js/pointer.js
+++ b/app/js/pointer.js
@@ -137,6 +137,13 @@ const downloadImage = () => {
         Math.round(X / factor), Math.round(Y / factor))
 }
 
+const downloadLink = () => {
+    const url = document.getElementById("url-hover")?.textContent
+    if (url) {
+        TABS.currentPage().downloadURL(url)
+    }
+}
+
 const inspectElement = () => {
     const {top, left} = offset()
     TABS.currentPage().inspectElement(Math.round(X + left), Math.round(Y + top))
@@ -317,6 +324,7 @@ module.exports = {
     releaseKeys,
     leftClick,
     rightClick,
+    downloadLink,
     downloadImage,
     inspectElement,
     insertAtPosition,

--- a/app/pages/help.html
+++ b/app/pages/help.html
@@ -45,6 +45,9 @@
             <li><kbd>e</kbd> - Switch to <a class="explore" href="#action.toExploreMode">explore mode</a> (for navigating to websites or searching the web)</li>
             <li><kbd>f</kbd> - Switch to <a class="follow" href="#action.startFollowCurrentTab">follow mode</a> (for clicking buttons or links based on keys)</li>
             <li><kbd>/</kbd> - Switch to <a class="search" href="#action.toSearchMode">search mode</a> (for locating text in the page, use <kbd>n</kbd> and <kbd>N</kbd> to switch between matches)</li>
+            <li><kbd>v</kbd> - Switch to <a class="pointer" href="#pointer">pointer mode</a> (for hovering over links, downloading images, copying link urls, etc.)<ul>
+                <li><kbd>v</kbd> - Then switch to <a class="visual" href="#pointer.startVisualSelect">visual mode</a> (for selecting text)</li>
+            </ul></li>
         </ul>
         You can see the current mode at all times in the navbar, next to the url.
         Vieb is separated into different modes, most importantly normal mode.
@@ -804,6 +807,8 @@
         Distribute the windows inside a split evenly. This does not necessarily mean that all windows will be of the same size, for example if you have a vertical split, with on the left side a window, but on the right side a horizontal sub-split with two windows.
         <h2 id="pointer">Pointer</h2>
         Vieb has a <span class="pointer">pointer mode</span> to hover over links, download images or inspect an element at a position. The pointer can be moved in many different ways, most of which are by default mapped similar to Vim's normal mode. Additionally, after entering <span class="pointer">pointer mode</span>, it's also possible to start selecting text using <span class="visual">visual mode</span>. By default, the bindings of these two modes are similar, with the biggest difference being that text will be selected between the initial and current pointer position. See <a href="#pointer.startVisualSelect">pointer.startVisualSelect</a> to activate <span class="visual">visual mode</span> and <a href="#pointer.copyAndStop">pointer.copyAndStop</a> to copy the hovered link or selected text.
+        <h3 id="pointer.start">pointer.start</h3>
+        Switch to <a href="#pointer" class="pointer">pointer mode</a>, which enables a movable pointer.  The pointer can be used to hover over links, download images or inspect an element at a position. It can be moved in many different ways, most of which are by default mapped similar to Vim's normal mode. See <a href="#pointer.startVisualSelect">pointer.startVisualSelect</a> to activate <a href="#visual" class="visual">visual mode</a> and <a href="#pointer.copyAndStop">pointer.copyAndStop</a> to copy the hovered link or selected text.
         <h3 id="pointer.leftClick" countable="true">pointer.leftClick</h3>
         Simulate a left mouse click at the current pointer location. See also <a href="#pointer.rightClick">pointer.rightClick</a>.
         <h3 id="pointer.rightClick" countable="true">pointer.rightClick</h3>

--- a/app/pages/help.html
+++ b/app/pages/help.html
@@ -810,6 +810,8 @@
         Execute a right mouse click at the pointer position. Unless the website has implemented functionality for this, no right-click menu will open, as Vieb does not have a right-click menu.
         <h3 id="pointer.downloadImage">pointer.downloadImage</h3>
         Download an image at the current pointer position. If there are multiple images at the pointer location, only the first one will be downloaded. The name will be automatically set, and downloaded files will be stored in <a href="#downloadpath">downloadpath</a>. This action will search specifically for img and svg tags at a position.
+        <h3 id="pointer.downloadLink">pointer.downloadLink</h3>
+        Downloads the link at the current point position. The name will be automatically set, and downloaded files will be stored in <a href="#downloadpath">downloadpath</a>.
         <h3 id="pointer.inspectElement">pointer.inspectElement</h3>
         Inspect an element at the current pointer position. This action will open a devtools window if the devtools are not opened yet. The <a href="#devtoolsposition">devtoolsposition</a> is not used when inspecting an element, as it will open a devtools window. If you want to open the devtools differently, please open the devtools with the <a href="#:devtools">:devtools</a> command first. The "inspectElement" action will use the existing devtools to inspect the element in.
         <h3 id="pointer.insertAtPosition">pointer.insertAtPosition</h3>


### PR DESCRIPTION
I'm not convinced this is the best way to do this but I'd like a way to copy link urls to the clipboard.  And also to download files that vieb would otherwise open directly (PDFs, but that's another issue).

This PR adds two new variants of the follow mode.  A yank mode (initiated by `action.startFollowYank`) which copies the link once picked, and a download mode (initiated by `action.startFollowDownload`) which downloads the picked link.  The default keybindings (`;y` and `;d`) are taken from pentadactyl; I believe qutebrowser uses the same ones.

 - I realize that this stretches the name of the "follow" mode a bit.  Pentadactyl/etc. use the name "(extended) hint mode" instead for the follow mode.

 - There is no visual indication what will happen once you pick a link (click, open a new tab, yank to clipboard, download).  This was already a (minor) issue since you couldn't tell if follow would open a new tab or not.  But now it's even more unclear as there are more actions that can take place after follow mode.

 - The download confirmation popup still shows up.  It might be a good idea to disable it in this case (and also in `pointer.downloadImage`).