### PR TITLE
Style changes to click-to-open on downloads.

### DIFF
--- a/app/colors/default.css
+++ b/app/colors/default.css
@@ -245,7 +245,7 @@ webview {pointer-events: none;position: fixed;display: none;}
 #cookiespage .remove {height: 1em;width: 1em;margin: auto 0;cursor: pointer;}
 /* downloads */
 #downloadspage .download {background: var(--special-page-element-bg);margin-bottom: 1em;border: .1em solid var(--special-page-element-border);}
-#downloadspage .title {margin: .4em;font-size: 1.5em;width: calc(100% - 4em);}
+#downloadspage .title {margin: .4em;font-size: 1.5em;width: calc(100% - 4em);cursor:pointer;}
 #downloadspage progress {-webkit-appearance: none;width: calc(100% - 1em);margin: .5em;}
 #downloadspage progress::-webkit-progress-value {background: var(--download-progress-fg);}
 #downloadspage progress::-webkit-progress-bar {background: var(--download-progress-bg);}

--- a/app/js/preloads/downloads.js
+++ b/app/js/preloads/downloads.js
@@ -95,8 +95,12 @@ const addDownload = (download, id) => {
     element.appendChild(togglePause)
     // Title
     const title = document.createElement("div")
+    title.title = "Click to open"
     title.textContent = download.name
     title.className = "title"
+    title.addEventListener("click", () => {
+        ipcRenderer.send("open-download", file.textContent)
+    })
     element.appendChild(title)
     // Progress
     const progress = document.createElement("progress")
@@ -138,6 +142,7 @@ const addDownload = (download, id) => {
     downloadUrl.textContent = decodeURIComponent(download.url)
     misc.appendChild(downloadUrl)
     const file = document.createElement("span")
+    file.title = "Click to open"
     file.className = "filelocation"
     file.textContent = download.file
     file.addEventListener("click", () => {

--- a/app/js/preloads/notifications.js
+++ b/app/js/preloads/notifications.js
@@ -27,6 +27,7 @@ window.addEventListener("DOMContentLoaded", () => {
             element.className = "notification"
             if (notification.click?.type === "download-success") {
                 element.classList.add("filelocation")
+                element.title = "Click to open"
                 element.addEventListener("click", () => {
                     ipcRenderer.send("open-download", notification.click.path)
                 })


### PR DESCRIPTION
 - Render the filename in the download list as a link.
 - Accept clicks on the title in the download list.
 - Add a tooltip in the notification list.

I'm not sure there's a good way to make this discoverable in the pop-up notifications, short of adding a "(click to open)" text or a "↗" arrow.  But that seems a bit too in-your-face.