### PR TITLE
Improve follow performance

### DIFF
--- a/app/js/follow.js
+++ b/app/js/follow.js
@@ -163,8 +163,7 @@ const parseAndDisplayLinks = newLinks => {
     // therefor the slice index is 0 to 26^2 - 1.
     links = links.slice(0, 675)
     const factor = TABS.currentPage().getZoomFactor()
-    const followElement = document.getElementById("follow")
-    followElement.textContent = ""
+    const followChildren = []
     links.forEach((link, index) => {
         if (!link) {
             return
@@ -198,7 +197,7 @@ const parseAndDisplayLinks = newLinks => {
             }
         }
         linkElement.addEventListener("mouseup", onclickListener)
-        followElement.appendChild(linkElement)
+        followChildren.push(linkElement)
         // Show a border around the link
         const borderElement = document.createElement("span")
         borderElement.className = `follow-${link.type}-border`
@@ -211,8 +210,9 @@ const parseAndDisplayLinks = newLinks => {
         const height = link.height * factor
         borderElement.style.height = `${height}px`
         borderElement.addEventListener("mouseup", onclickListener)
-        followElement.appendChild(borderElement)
+        followChildren.push(borderElement)
     })
+    document.getElementById("follow").replaceChildren(...followChildren)
 }
 
 const enterKey = async id => {

--- a/app/js/preloads/follow.js
+++ b/app/js/preloads/follow.js
@@ -69,15 +69,16 @@ ipcRenderer.on("focus-first-text-input", async () => {
 
 const getLinkFollows = allLinks => {
     // A tags with href as the link, can be opened in new tab or current tab
-    allLinks.push(...allElementsBySelectors("url", urls))
-    document.querySelectorAll("a *").forEach(el => {
-        const baseLink = el.closest("a")
-        if (baseLink && !allLinks.includes(baseLink)) {
-            const clickableSubElement = parseElement(el, "url")
-            if (clickableSubElement) {
-                clickableSubElement.url = baseLink.href || ""
-                allLinks.push(clickableSubElement)
-            }
+    document.querySelectorAll(urls.join(",")).forEach(e => {
+        const baseLink = parseElement(e, "url")
+        if (baseLink) {
+            allLinks.push(baseLink)
+        } else {
+            // Try subelements instead, for example if the link is not
+            // visible or `display: none`, but a sub-element is absolutely
+            // positioned somewhere else.
+            allLinks.push(...[...e.querySelectorAll("*")]
+                .map(c => parseElement(c, "url")).filter(l => l))
         }
     })
 }

--- a/app/js/preloads/follow.js
+++ b/app/js/preloads/follow.js
@@ -212,6 +212,9 @@ const findClickPosition = (element, rects) => {
     return {clickable, dimensions}
 }
 
+const rectOutsideWindow = r => r.bottom < 0 || r.top > window.innerHeight
+    || r.right < 0 || r.left > window.innerWidth
+
 const parseElement = (element, type) => {
     // The body shouldn't be considered clickable on it's own,
     // Even if listeners are added to it.
@@ -222,10 +225,7 @@ const parseElement = (element, type) => {
     }
     // First (quickly) check that element is visible at all
     const boundingRect = element.getBoundingClientRect()
-    const completelyOutsideWindow = boundingRect.bottom < 0
-        || boundingRect.top > window.innerHeight
-        || boundingRect.right < 0 || boundingRect.left > window.innerWidth
-    if (completelyOutsideWindow) {
+    if (rectOutsideWindow(boundingRect)) {
         return null
     }
     const isHidden = window.getComputedStyle(element).visibility === "hidden"
@@ -244,9 +244,7 @@ const parseElement = (element, type) => {
     // - Too small to properly click on using a regular browser
     const tooSmall = dimensions.width <= 2 || dimensions.height <= 2
     // - The element isn't actually visible on the user's current window
-    const outsideWindow = dimensions.bottom < 0
-        || dimensions.top > window.innerHeight
-        || dimensions.right < 0 || dimensions.left > window.innerWidth
+    const outsideWindow = rectOutsideWindow(dimensions)
     // - The element is too big to actually make sense to click on by choice
     const tooBig = dimensions.width >= window.innerWidth
         || dimensions.height >= window.innerHeight


### PR DESCRIPTION
On some pages, entering follow mode can take a second or more on my machine.  Zulip is a particularly bad example.  This is a publicly accessible page where entering follow mode takes a long time: https://www.ikea.com/nl/nl/campaigns/slimme-koopjes-betaalbare-producten-voor-elke-dag-pub9015c218  Just computing the follow links (the `sendFollowLinks` function) takes 492ms for me.

This PR adds some easy speed-ups, without changing the general approach; the result should still be the same.  With the change, the ikea example only takes 70ms now.

I've split the `sendFollowLinks` function into multiple parts to facilitate profiling.  Most of the time (75%) is spent in the `parseElement` function.

Can you explain what problem the change to the link detection in 5697f580f165bf6620517b734ef1de23882c9651 fixes?  It adds quite a bit of runtime (25% in the example).