### PR TITLE
Make addEventListener/removeEventListener wrapper more robust.

### DIFF
--- a/app/js/preloads/follow.js
+++ b/app/js/preloads/follow.js
@@ -276,27 +276,18 @@ const realAdd = EventTarget.prototype.addEventListener
 EventTarget.prototype.addEventListener = function(type, listener, options) {
     try {
         realAdd.apply(this, [type, listener, options])
+        eventListeners[type]?.add(this)
     } catch (e) {
         // This is a bug in the underlying website
-        return
-    }
-    if (eventListeners[type]) {
-        eventListeners[type].add(this)
     }
 }
 const realRemove = EventTarget.prototype.removeEventListener
 EventTarget.prototype.removeEventListener = function(type, listener, options) {
     try {
         realRemove.apply(this, [type, listener, options])
+        eventListeners[type]?.delete(this)
     } catch (e) {
         // This is a bug in the underlying website
-    }
-    if (eventListeners[type]) {
-        try {
-            eventListeners[type].delete(this)
-        } catch (e) {
-            // The element was already removed from the list before
-        }
     }
 }
 


### PR DESCRIPTION
This fixes an error with the follow mode on https://observablehq.com/@eric-wieser/lean-ga-imports

On that page, `WeakSet.add` unexpectedly throws an exception when adding a `HTMLButtonElement`.  This is probably a bug in chrome, because you should be able to add any non-null object.

I haven't run across this bug anywhere else, and it only happens for a single button on that page.  So this PR just ignores the exception.