### PR TITLE
Add internaldevtools command to open developer tools of main window.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The releases of Vieb aim to follow [semantic versioning](https://semver.org).
 - Clickable download finish notification that will open the file in the default application (if using the mouse)
 - Additional Vieb config location for colorschemes, viebrc and blocklists inside "~/.vieb"
 - New permission groups for midi, persistentstorage and clipboardread (all 3 remain by default blocked, but are no longer grouped as unknown)
+- Internaldevtools command that opens developer tools for the main Vieb window
 
 ### Changed
 

--- a/app/index.js
+++ b/app/index.js
@@ -1004,6 +1004,8 @@ ipcMain.on("add-devtools", (_, pageId, devtoolsId) => {
     page.openDevTools()
     devtools.executeJavaScript("window.location.reload()")
 })
+ipcMain.on("open-internal-devtools",
+    () => mainWindow.webContents.openDevTools({"mode": "undocked"}))
 ipcMain.on("destroy-window", () => {
     cancellAllDownloads()
     mainWindow.destroy()

--- a/app/js/command.js
+++ b/app/js/command.js
@@ -250,6 +250,8 @@ const openDevTools = (position = null, trailingArgs = false) => {
     }
 }
 
+const openInternalDevTools = () => ipcRenderer.send("open-internal-devtools")
+
 const openSpecialPage = (specialPage, section = null) => {
     // Open the url in the current or new tab, depending on currently open page
     const pageUrl = UTIL.specialPagePath(specialPage, section)
@@ -531,6 +533,7 @@ const commands = {
     "quitall": quitall,
     "colorscheme": colorscheme,
     "devtools": openDevTools,
+    "internaldevtools": openInternalDevTools,
     "reload": reload,
     "restart": restart,
     "v": () => openSpecialPage("version"),

--- a/app/pages/help.html
+++ b/app/pages/help.html
@@ -465,6 +465,11 @@
             <li><span class="command-block">:devtools tab</span> - Open the developer tools of the current page in a new tab</li>
         </ul>
         The devtools command can be used to open the developer tools of the current page. If no argument is given for the devtools position, it will open at the position configured by <a href="#devtoolsposition">devtoolsposition</a>. The accepted positions for this command are the same as that of the setting. It's not possible to open multiple instances of the devtools for the same page, you can open one type of devtools per tab. By default these tools will have dark mode and some security settings enabled. If the devtools are opened as a Vieb tab or split (so not windowed) all regular Vieb action can be used to interact with the developer tools.
+        <h3 id=":internaldevtools">:internaldevtools</h3>
+        <ul>
+            <li><span class="command-block">:internaldevtools</span> - Open the developer tools of the Vieb main browser window</li>
+        </ul>
+        The internaldevtools command opens the developer tools of the main Vieb window (containing the url bar, tab list, etc.).  This is mainly useful to debug Vieb itself.
         <h3 id=":colorscheme">:colorscheme</h3>
         <ul>
             <li><span class="command-block">:colorscheme</span> - Show the currently active colorscheme</li>


### PR DESCRIPTION
It's very useful to be able to quickly open the devtools for a running vieb instance, e.g. to figure out why some action takes longer than expected.

I didn't think too hard about the command name.  It might be nice to open the internal dev tools as a tab, but this would probably require larger changes to addTab().

This already came up in another issue: https://github.com/Jelmerro/Vieb/issues/90#issuecomment-727245720 https://github.com/Jelmerro/Vieb/issues/90#issuecomment-727229717