### PR TITLE
Implementing "quickmarks"/marks feature

### DIFF
--- a/app/js/actions.js
+++ b/app/js/actions.js
@@ -380,6 +380,43 @@ const setFocusCorrectly = () => {
     }
 }
 
+const mark = (inputMark, inputUrl) => {
+    if (!UTIL.getUrlForMark(inputMark)) {
+        newMapping = ""
+        SETTINGS.get("marks").split(",").forEach(mapping => {
+            const [mark, url] = mapping.split("~")
+            if (mark && url && requestedMark
+                && mark === requestedMark) {
+                url = inputUrl;
+            }
+            newMapping = `${newmapping},${mark}~${url}`
+        })
+    } else {
+        let marks = SETTINGS.get("marks")
+        if (marks) {
+            marks = `${marks},${inputMark}~${inputUrl}`
+        } else {
+            marks = `${inputMark}~${inputUrl}`
+        }
+        SETTINGS.set("marks", marks)
+    }
+}
+
+const retrieveMark = (requestedMark) => {
+    let outputUrl = ""
+
+    SETTINGS.get("marks").split(",").forEach(mapping => {
+        const [mark, url] = mapping.split("~")
+        if (mark && url && requestedMark
+            && mark === requestedMark) {
+            outputUrl = url;
+        }
+    })
+
+    return outputUrl
+}
+
+
 module.exports = {
     toCommandMode,
     toExploreMode,
@@ -447,5 +484,7 @@ module.exports = {
     commandHistoryNext,
     toggleFullscreen,
     useEnteredData,
-    setFocusCorrectly
+    setFocusCorrectly,
+    mark,
+    retrieveMark,
 }

--- a/app/js/actions.js
+++ b/app/js/actions.js
@@ -349,7 +349,7 @@ const useEnteredData = () => {
             if (searchword && url && query
                 && location.substr(0, searchword.length) === searchword
                 && /\S/.test(query)) {
-                    location = UTIL.stringToUrl(url.replace(/%s/g, query))
+                location = UTIL.stringToUrl(url.replace(/%s/g, query))
             }
         })
 
@@ -381,17 +381,21 @@ const setFocusCorrectly = () => {
 }
 
 const mark = (inputMark, inputUrl) => {
-    if (!UTIL.getUrlForMark(inputMark)) {
-        newMapping = ""
+    if (UTIL.getUrlForMark(inputMark)) {
+        // Update URL for an existing mark
+        let newMapping = ""
         SETTINGS.get("marks").split(",").forEach(mapping => {
-            const [mark, url] = mapping.split("~")
-            if (mark && url && requestedMark
-                && mark === requestedMark) {
-                url = inputUrl;
+            const [savedMark] = mapping.split("~")
+            let [, url] = mapping.split("~")
+            if (savedMark && url && inputMark
+                && savedMark === inputMark) {
+                url = inputUrl
             }
-            newMapping = `${newmapping},${mark}~${url}`
+            newMapping = `${newMapping},${savedMark}~${url}`
         })
+        SETTINGS.set("marks", newMapping)
     } else {
+        // Add a new mark
         let marks = SETTINGS.get("marks")
         if (marks) {
             marks = `${marks},${inputMark}~${inputUrl}`
@@ -402,14 +406,14 @@ const mark = (inputMark, inputUrl) => {
     }
 }
 
-const retrieveMark = (requestedMark) => {
+const retrieveMark = requestedMark => {
     let outputUrl = ""
 
     SETTINGS.get("marks").split(",").forEach(mapping => {
-        const [mark, url] = mapping.split("~")
-        if (mark && url && requestedMark
-            && mark === requestedMark) {
-            outputUrl = url;
+        const [savedMark, url] = mapping.split("~")
+        if (savedMark && url && requestedMark
+            && savedMark === requestedMark) {
+            outputUrl = url
         }
     })
 
@@ -486,5 +490,5 @@ module.exports = {
     useEnteredData,
     setFocusCorrectly,
     mark,
-    retrieveMark,
+    retrieveMark
 }

--- a/app/js/command.js
+++ b/app/js/command.js
@@ -526,7 +526,7 @@ const callAction = (...args) => {
     }
 }
 
-const mark = (markToSet) => {
+const mark = markToSet => {
     if (!markToSet || !markToSet.trim()) {
         UTIL.notify(
             "Exactly one mark character is required for the mark command",
@@ -539,10 +539,10 @@ const mark = (markToSet) => {
             "warn")
         return
     }
-    ACTIONS.mark(markToSet, UTIL.urlToString(TABS.currentPage().src));
+    ACTIONS.mark(markToSet, UTIL.urlToString(TABS.currentPage().src))
 }
 
-const retrieveMark = (requestedMark) => {
+const retrieveMark = requestedMark => {
     if (!requestedMark || !requestedMark.trim()) {
         UTIL.notify(
             "Exactly one mark character is required for the mark command",
@@ -559,7 +559,6 @@ const retrieveMark = (requestedMark) => {
     if (url) {
         TABS.navigateTo(UTIL.stringToUrl(url))
     }
-
 }
 
 const commands = {

--- a/app/js/command.js
+++ b/app/js/command.js
@@ -526,6 +526,42 @@ const callAction = (...args) => {
     }
 }
 
+const mark = (markToSet) => {
+    if (!markToSet || !markToSet.trim()) {
+        UTIL.notify(
+            "Exactly one mark character is required for the mark command",
+            "warn")
+        return
+    }
+    if (/[^a-zA-Z0-9]/.test(markToSet)) {
+        UTIL.notify(
+            "The mark must be one character or one number only",
+            "warn")
+        return
+    }
+    ACTIONS.mark(markToSet, UTIL.urlToString(TABS.currentPage().src));
+}
+
+const retrieveMark = (requestedMark) => {
+    if (!requestedMark || !requestedMark.trim()) {
+        UTIL.notify(
+            "Exactly one mark character is required for the mark command",
+            "warn")
+        return
+    }
+    if (/[^a-zA-Z0-9]/.test(requestedMark)) {
+        UTIL.notify(
+            "The mark must be one character or one number only",
+            "warn")
+        return
+    }
+    const url = ACTIONS.retrieveMark(requestedMark)
+    if (url) {
+        TABS.navigateTo(UTIL.stringToUrl(url))
+    }
+
+}
+
 const commands = {
     "q": quit,
     "quit": quit,
@@ -567,7 +603,9 @@ const commands = {
     "comclear": () => {
         userCommands = {}
     },
-    "call": callAction
+    "call": callAction,
+    "mark": mark,
+    "retrieveMark": retrieveMark
 }
 let userCommands = {}
 

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -53,6 +53,7 @@ const defaultSettings = {
     "keeprecentlyclosed": true,
     "ignorecase": false,
     "incsearch": true,
+    "marks": "",
     "maxmapdepth": 10,
     "mintabwidth": 28,
     "mouse": false,
@@ -113,6 +114,7 @@ const freeText = ["downloadpath", "search", "vimcommand"]
 const listLike = [
     "containercolors",
     "favoritepages",
+    "marks",
     "permissionsallowed",
     "permissionsblocked",
     "redirects",
@@ -391,6 +393,34 @@ const checkOther = (setting, value) => {
                 return false
             }
             knownSearchwords.push(keyword)
+        }
+    }
+    if (setting === "marks") {
+        let knownMarks = []
+        for (const mark of value.split(",")) {
+            if (!mark.trim()) {
+                continue
+            }
+            if ((mark.match(/~/g) || []).length !== 1) {
+                UTIL.notify(`Invalid marks entry: ${mark}\n`
+                    + "Entries must have exactly one ~ to separate the "
+                    + "mark character from the URL", "warn")
+                return false
+            }
+            const [markCharacter, url] = mark.split("~")
+            if (markCharacter.length === 0 || /[^a-zA-Z0-9]/.test(markCharacter)) {
+                UTIL.notify(`Invalid marks entry: ${mark}\n`
+                    + "The mark before the ~ must be one character "
+                    + "and contain only letters or numbers", "warn")
+                return false
+            }
+            if (knownMarks.includes(markCharacter)) {
+                UTIL.notify(`Invalid mark entry: ${mark}\n`
+                    + `The mark ${markCharacter} was already defined. `
+                    + "A mark must be defined only once", "warn")
+                return false
+            }
+            knownMarks.push(mark)
         }
     }
     if (["favoritepages", "startuppages"].includes(setting)) {

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -396,7 +396,7 @@ const checkOther = (setting, value) => {
         }
     }
     if (setting === "marks") {
-        let knownMarks = []
+        const knownMarks = []
         for (const mark of value.split(",")) {
             if (!mark.trim()) {
                 continue
@@ -407,8 +407,9 @@ const checkOther = (setting, value) => {
                     + "mark character from the URL", "warn")
                 return false
             }
-            const [markCharacter, url] = mark.split("~")
-            if (markCharacter.length === 0 || /[^a-zA-Z0-9]/.test(markCharacter)) {
+            const [markCharacter] = mark.split("~")
+            if (markCharacter.length === 0
+                || /[^a-zA-Z0-9]/.test(markCharacter)) {
                 UTIL.notify(`Invalid marks entry: ${mark}\n`
                     + "The mark before the ~ must be one character "
                     + "and contain only letters or numbers", "warn")

--- a/app/js/util.js
+++ b/app/js/util.js
@@ -103,7 +103,7 @@ const isSearchword = location => {
         if (searchword && url && query
             && location.substr(0, searchword.length) === searchword
             && /\S/.test(query)) {
-                found = true
+            found = true
         }
     })
     return found
@@ -360,7 +360,7 @@ const getUrlForMark = requestedMark => {
         }
     })
 
-    return url
+    return outputUrl
 }
 
 const stringToUrl = location => {

--- a/app/js/util.js
+++ b/app/js/util.js
@@ -349,6 +349,20 @@ const deleteFile = (loc, err = null) => {
     return false
 }
 
+const getUrlForMark = requestedMark => {
+    let outputUrl = ""
+
+    SETTINGS.get("marks").split(",").forEach(mapping => {
+        const [mark, url] = mapping.split("~")
+        if (mark && url && requestedMark
+            && mark === requestedMark) {
+            outputUrl = url
+        }
+    })
+
+    return url
+}
+
 const stringToUrl = location => {
     const specialPage = pathToSpecialPageName(location)
     if (specialPage.name) {
@@ -440,6 +454,7 @@ module.exports = {
     clearCookies,
     clearLocalStorage,
     expandPath,
+    getUrlForMark,
     isObject,
     pathExists,
     isDir,


### PR DESCRIPTION
Implementing marks to address #100 

I still have to make the help page and make default bindings of `M` and `g` to visit the marks, and do some more testing.

What do you think about this approach, though? I added two commands, `mark` and `retrieveMark`, ~~which call similarly named actions,~~ added a default setting and validation, and added a UTIL to get the URL for the mark setting.

~~I tried to follow the existing flow but I think that I could just do all the logic in command.js, and not call `ACTIONS` at all. I'll try that next.~~ *Edit:* I've now implemented this in the latest commit


This isn't ready for check-in yet, but I wanted to get some feedback on this approach.