### PR TITLE
Fix click-to-insert if site uses stopPropagation()

### DIFF
--- a/app/js/preloads/follow.js
+++ b/app/js/preloads/follow.js
@@ -424,7 +424,8 @@ const clickListener = (e, frame = null) => {
         })
     }
 }
-window.addEventListener("click", clickListener)
+window.addEventListener("click", clickListener,
+    {"capture": true, "passive": true})
 
 const contextListener = (e, frame = null) => {
     if (e.isTrusted) {


### PR DESCRIPTION
For example, clicking on the search box in duckduckgo did not enable insert mode.