### PR TITLE
Lazy tab restore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The releases of Vieb aim to follow [semantic versioning](https://semver.org).
 
 - Mute command to toggle the audio playback status of a tab (either mute or unmute)
 - Setting "respectsitecontextmenu" to toggle if Vieb should show it's menu on websites that already provide one
+- Setting "restoretabslazily" to restore tabs lazily (loading non-pinned tabs only once they're visible)
 
 ### Changed
 

--- a/app/colors/default.css
+++ b/app/colors/default.css
@@ -154,16 +154,16 @@ body:not(#app) ::placeholder {color: var(--placeholder-text);}
 #tabs.scroll {overflow-x: auto;}
 #tabs.wrap {flex-wrap: wrap;}
 /* pages container */
+.webview {pointer-events: none;position: fixed;display: none;}
 #page-container, #current-page, .visible-page {display: flex;flex: 1;height: 100%;width: 100%;}
-#pages.multiple webview {border: solid .15em transparent;box-sizing: border-box;}
+#pages.multiple .webview {border: solid .15em transparent;box-sizing: border-box;}
 #pages.multiple #current-page {border-color: var(--tab-split);}
-webview {pointer-events: none;position: fixed;display: none;}
 #pagelayout {display: flex;height: 100%;width: 100%;}
 #pagelayout * {flex: 1;}
 #pagelayout.hor, #pagelayout .hor {flex-direction: row;display: flex;}
 #pagelayout.ver, #pagelayout .ver {flex-direction: column;display: flex;}
 /* fullscreen */
-#app.fullscreen #navbar, #app.fullscreen #tabs, #app.fullscreen webview {display: none;}
+#app.fullscreen #navbar, #app.fullscreen #tabs, #app.fullscreen .webview {display: none;}
 #app.fullscreen #current-page {display: flex;width: 100vw;height: 100vh;top: 0;bottom: 0;left: 0;right: 0;}
 /* conditionally hide tabs or navbar from the vieb window */
 #app.tabshidden #tabs {display: none;}
@@ -203,7 +203,7 @@ webview {pointer-events: none;position: fixed;display: none;}
 #suggest-dropdown div.selected {background: var(--suggestions-selected);}
 /* mouse related */
 #invisible-overlay {-webkit-app-region: drag;position: absolute;top: 0;left: 0;width: 100vw;height: 100vh;z-index: 50;}
-#app.mouse webview {pointer-events: all;}
+#app.mouse .webview {pointer-events: all;}
 #app.mouse #invisible-overlay {display: none;}
 #app[current-mode=insert] #invisible-overlay {display: none;}
 #app.mouse #navbar, #app.mouse #tabs {pointer-events: all;}

--- a/app/js/pagelayout.js
+++ b/app/js/pagelayout.js
@@ -290,7 +290,7 @@ const removeRedundantContainers = () => {
 const applyLayout = () => {
     document.querySelectorAll("#pagelayout *[link-id]").forEach(element => {
         const id = element.getAttribute("link-id")
-        const page = document.querySelector(`#pages webview[link-id='${id}']`)
+        const page = document.querySelector(`#pages .webview[link-id='${id}']`)
         if (!page) {
             element.parentNode.removeChild(element)
         }
@@ -309,7 +309,7 @@ const applyLayout = () => {
     const visibleTabs = []
     document.querySelectorAll("#pagelayout *[link-id]").forEach(element => {
         const id = element.getAttribute("link-id")
-        const page = document.querySelector(`#pages webview[link-id='${id}']`)
+        const page = document.querySelector(`#pages .webview[link-id='${id}']`)
         visibleTabs.push(document.querySelector(`#tabs span[link-id='${id}']`))
         visiblePages.push(page)
         const dimensions = element.getBoundingClientRect()

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -84,6 +84,7 @@ const defaultSettings = {
     "requesttimeout": 20000,
     "respectsitecontextmenu": true,
     "restoretabs": true,
+    "restoretabslazily": false,
     "restorewindowmaximize": true,
     "restorewindowposition": true,
     "restorewindowsize": true,

--- a/app/js/tabs.js
+++ b/app/js/tabs.js
@@ -67,7 +67,8 @@ const init = () => {
                             return t
                         }).forEach(tab => addTab({
                             ...tab,
-                            "lazy": lazy && !tab.pinned
+                            "lazy": lazy && !tab.pinned,
+                            "switchTo": false
                         }))
                     }
                     if (Array.isArray(parsed.closed)) {
@@ -292,10 +293,10 @@ const addTab = options => {
         sessionName = currentPage()?.getAttribute("container") || "main"
     }
     let addNextToCurrent = SETTINGS.get("tabnexttocurrent")
-    addNextToCurrent = addNextToCurrent && listTabs().length > 0
     if (options.inverted) {
         addNextToCurrent = !addNextToCurrent
     }
+    addNextToCurrent = addNextToCurrent && currentTab()
     const tabs = document.getElementById("tabs")
     const pages = document.getElementById("pages")
     const tab = document.createElement("span")

--- a/app/pages/help.html
+++ b/app/pages/help.html
@@ -663,6 +663,8 @@
         With this toggle you can decide if Vieb's menu should appear even if the website already provides one. By default it will respect the website's menu, and not show Vieb's menu. If you disable this toggle, you will be able to right-click on everything, even if the website has explicitly disabled or overwritten it.
         <h3 id="restoretabs">restoretabs</h3>
         Toggle for restoring tabs you had open during the previous browsing session. If enabled, all tabs you had open when you quit Vieb last time, will automatically open again when you start Vieb. If you have configured any <a href="#startuppages">startuppages</a>, they will be opened after restoring the previous tabs. If this setting is disabled, tabs won't be restored, but will possibly be stored as recently closed tabs so you can reopen them, which is configured with <a href="#keeprecentlyclosed">keeprecentlyclosed</a>. Tabs which are pinned by the <a href="#:pin">:pin</a> command are always restored, regardless of the restoretabs setting. The container each tab was using is always remembered on restart.
+        <h3 id="restoretabslazily">restoretabslazily</h3>
+        Toggle for restoring tabs lazily. If enabled, only the currently visible tab and the pinned tabs will be loaded immediately when restoring tabs. The other tabs will only be loaded after switching to them. This option is useful to make Vieb start up faster. It only has an effect if <a href="#restoretabs">restoretabs</a> is enabled.
         <h3 id="restorewindowmaximize">restorewindowmaximize</h3>
         Toggle for remembering and restoring the window maximization state after restarting Vieb.
         <h3 id="restorewindowposition">restorewindowposition</h3>


### PR DESCRIPTION
At the moment I have 51 open tabs.  Restarting vieb and restoring all the tabs takes a while.

This PR adds support to restore tabs lazily.  That is, tabs that are not pinned or visible are not loaded immediately.  Instead, we set a `lazy` attribute on them.  When switching to a tab with the `lazy` attribute set, the webview is automatically loaded.

(This can also be used to "suspend" tabs as discussed in #69: if you run the `:restart` command with the `restoretabslazily` option enabled, then all tabs except the current one and the pinned tabs will be suspended.)