### PR TITLE
Quoting the tempfile path for vimcommand

### DIFF
--- a/app/renderer/actions.js
+++ b/app/renderer/actions.js
@@ -288,7 +288,7 @@ const editWithVim = () => {
             }
         } else {
             const {exec} = require("child_process")
-            command = exec(`${getSetting("vimcommand")} ${tempFile}`, err => {
+            command = exec(`${getSetting("vimcommand")} "${tempFile}"`, err => {
                 if (err) {
                     notify("Command to edit files with vim failed, "
                         + "please update the 'vimcommand' setting", "err")


### PR DESCRIPTION
On macOS, the tempfile path contains a space. Lack of quoting caused
the path to be split as a separate arg send to the editor and
prevented opening the file.