### PR TITLE
Add two small fixes to verticaltabs.css

### DIFF
--- a/app/colors/verticaltabs.css
+++ b/app/colors/verticaltabs.css
@@ -18,6 +18,8 @@
 
 #tabs {overflow-x: hidden;overflow-y: auto;position: absolute;left: 0;width: 15vw;height: calc(100vh - 2em);top: 2em;flex-direction: column;}
 #tabs > span {min-height: 1.9em;max-height: 1.9em;min-width: 0 !important;}
+#tabs > span.pinned {max-width: unset;width: unset;}
+#tabs :not(.visible-tab).pinned {background: #222;}
 #page-container {height: calc(100vh - 2em);position: absolute;top: 2em;left: 15vw;width: 85vw;}
 #app.fullscreen #page-container {height: 100vh;width: 100vw;top: 0;left: 0;}
 #app.tabshidden #page-container {width: 100vw;left: 0;}


### PR DESCRIPTION
If the tabs are vertical, the pinned tabs don't need to be small,
because the whole row is reserved for them anyways, so we unset the
max-width and width CSS properties.

But this results in a new UI fail: the pinned tabs are not easy to
tell say apart from non-pinned tabs, so to battle this, we add a
slightly darker color as their background (but only if they are not
actually currently selected, in which case we keep the color of the
"cursor").