### PR TITLE
add screenshot mappings to examples

### DIFF
--- a/app/examples/firefox
+++ b/app/examples/firefox
@@ -47,6 +47,7 @@ map <A-6> <:b 5>
 map <A-7> <:b 6>
 map <A-8> <:b 7>
 map <A-9> <:b 8>
+map <C-S> <:screenshot>
 vmap <C-f> <p.searchText>
 smap <F3> <nextSearchMatch>
 smap <C-g> <nextSearchMatch>

--- a/app/examples/surfingkeys
+++ b/app/examples/surfingkeys
@@ -90,6 +90,7 @@ nmap sy <openNewTab><toExploreMode>youtube <C-v><CR>
 nmap se <openNewTab><toExploreMode>wikipedia <C-v><CR>
 nmap ss <openNewTab><toExploreMode>stackoverflow <C-v><CR>
 nmap sh <openNewTab><toExploreMode>github <C-v><CR>
+nmap yg <:screenshot>
 nmap ? <:help>
 pmap v <p.startVisualSelect>
 pmap 0 <p.moveLeftMax>


### PR DESCRIPTION
Adds screenshot mappings to the example viebrcs. Chrome, Vivaldi, and Qutebrowser all have ways to screenshot the page, but they are not default keyboard shortcuts, so I left them out.