### PR TITLE
Small Download bug fix

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -797,7 +797,10 @@ ipcMain.on("create-session", (_, name, adblock, cache) => {
         let newFilename = item.getFilename()
         while (isFile(save)) {
             duplicateNumber += 1
-            const extStart = filename.indexOf(".")
+            let extStart = filename.lastIndexOf(".tar.")
+			if (extStart === -1) {
+				extStart = filename.lastIndexOf(".")
+			}
             if (extStart === -1) {
                 newFilename = `${filename} (${duplicateNumber})`
             } else {

--- a/app/index.js
+++ b/app/index.js
@@ -793,11 +793,11 @@ ipcMain.on("create-session", (_, name, adblock, cache) => {
         }
         const filename = item.getFilename()
         let save = joinPath(downloadSettings.downloadpath, filename)
-        let duplicateNumber = 1
+        let duplicateNumber = 0
         let newFilename = item.getFilename()
         while (isFile(save)) {
             duplicateNumber += 1
-            const extStart = filename.lastIndexOf(".")
+            const extStart = filename.indexOf(".")
             if (extStart === -1) {
                 newFilename = `${filename} (${duplicateNumber})`
             } else {


### PR DESCRIPTION
Slight deviation from how downloads work in other browsers.

![](https://github.com/cab-1729/Random-host/blob/main/Demonstration.png?raw=true)

This disrupts the filenames in case of extensions with two dots.