### PR TITLE
reduces page height on compact theme to fit the page view

### DIFF
--- a/app/colors/compact.css
+++ b/app/colors/compact.css
@@ -18,3 +18,4 @@
 #app {display: grid;grid-template: "navbar tabbar" 2em "main main" auto;}
 #navbar, #tabs {width: 50vw}
 #page-container{grid-area: main;}
+#page-container, #current-page, .visible-page{height:99%;}


### PR DESCRIPTION
For some reason the bottom of the page goes outside of the viewport. I added a line as a quick fix but I am not sure if it is the correct way to solve it.

Check the bottom and the scroll bar to notice the difference: 

[Error](https://i.imgur.com/dmFxk7J.png)
[Fix](https://i.imgur.com/gl6Yd9l.png)
