### PR TITLE
Added new 'paper' theme, and light compact theme

### DIFF
--- a/app/colors/light-compact.css
+++ b/app/colors/light-compact.css
@@ -1,0 +1,93 @@
+/*
+* Vieb - Vim Inspired Electron Browser
+* Copyright (C) 2020-2022 Jelmer van Arnhem
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+/* colors */
+:root {
+    /* general */
+    --bg: #eee;
+    --fg: #333;
+    --tab-background: #ddd;
+    --tab-suspended: #777;
+    --visible-tab: #fff;
+    --tab-crashed: #faa;
+    --mode-normal-fg: #333;
+    --mode-insert-fg: #0c0;
+    --mode-explore-fg: #0cc;
+    --mode-search-fg: #fb0;
+    --url-default: #ddd;
+    --url-search: #f80;
+    --url-searchwords: #f5f;
+    --url-url: #08f;
+    --url-suggest: #0c0;
+    --url-file: #fb0;
+    --suggestions-border: #eee;
+    --suggestions-bg: #ddd;
+    --suggestions-selected: #fff;
+    --suggestions-url: #08f;
+    --suggestions-file: #f80;
+    --notification-border: #aaa;
+    --notification-date: #777;
+    --notification-permission: #777;
+    --notification-error: #f33;
+    --notification-warning: #f80;
+    --notification-info: #08f;
+    --notification-success: #0c0;
+    /* special pages */
+    --link-color: #08f;
+    --link-underline: #0df;
+    --scrollbar-bg: #fff;
+    --scrollbar-thumb: #aaa7;
+    --button-disabled: #777;
+    --code-fg: #000;
+    --code-bg: #fff;
+    --special-page-element-bg: #ddd;
+    --special-page-element-border: #aaa;
+    --input-unfocused: #aaa;
+    --input-focused: #666;
+    --download-progress-fg: #fff;
+    --download-progress-bg: #eee;
+    --helppage-countable: #0c0;
+    /* sourceviewer */
+    --syntax-keyword: #d45;
+    --syntax-entity: #74c;
+    --syntax-constant: #06c;
+    --syntax-string: #036;
+    --syntax-variable: #e60;
+    --syntax-comment: #777;
+    --syntax-entity-tag: #284;
+    --syntax-markup-heading: #06c;
+    --syntax-markup-list: #760;
+    --syntax-markup-emphasis: #233;
+    --syntax-markup-addition-fg: #284;
+    --syntax-markup-addition-bg: #efe;
+    --syntax-markup-deletion-fg: #b22;
+    --syntax-markup-deletion-bg: #fee;
+}
+
+/* general */
+#tabs .status {filter: invert(.4);}
+
+/* special pages */
+#app #pointer, #cookiespage img, #downloadspage img, #historypage img {filter: invert(1);}
+.specialpage a::after {filter: invert(1);}
+#helppage .cheatsheet {filter: none;}
+#historypage img.favicon {filter: none;}
+
+/* compact mode */
+#app {display: grid;grid-template: "navbar tabbar" 2em "main main" auto;}
+#navbar, #tabs {width: 50vw}
+#page-container{grid-area: main;}

--- a/app/colors/paper-compact.css
+++ b/app/colors/paper-compact.css
@@ -91,7 +91,7 @@
     --download-progress-bg: #D8D5C7;
     --helppage-countable: #216609;
     /* sourceviewer */
-    --syntax-keyword: #CC3E28;
+    --syntax-keyword: #d45;
     --syntax-entity: #74c;
     --syntax-constant: #06c;
     --syntax-string: #036;
@@ -105,29 +105,29 @@
     --syntax-markup-addition-bg: #efe;
     --syntax-markup-deletion-fg: #b22;
     --syntax-markup-deletion-bg: #fee;
-    /* fine tuning */
+    /* fine tuning follow-links */
     --follow-text: #000;
-    --follow-url-bg: #bff;
-    --follow-url-border: #7dd;
-    --follow-url-hover: #7dd7;
+    --follow-url-bg: #bcf5f2;
+    --follow-url-border: #21ded4;
+    --follow-url-hover: rgba(33, 222, 212, 30%);
     --follow-click-bg: #fbb;
-    --follow-click-border: #d77;
-    --follow-click-hover: #d777;
-    --follow-insert-bg: #bfb;
-    --follow-insert-border: #7d7;
-    --follow-insert-hover: #7d77;
-    --follow-onclick-bg: #ffb;
-    --follow-onclick-border: #dd7;
-    --follow-onclick-hover: #dd77;
-    --follow-media-bg: #bbf;
-    --follow-media-border: #77d;
-    --follow-media-hover: #77d7;
-    --follow-image-bg: #fbf;
-    --follow-image-border: #d7d;
-    --follow-image-hover: #d7d7;
-    --follow-other-bg: #ddd;
-    --follow-other-border: #bbb;
-    --follow-other-hover: #bbb7;
+    --follow-click-border: #e92a0c;
+    --follow-click-hover: rgba(233, 42, 12, 30%);
+    --follow-insert-bg: #c9f9b9;
+    --follow-insert-border: #4aeb14;
+    --follow-insert-hover: rgba(74, 235, 20, 30%);
+    --follow-onclick-bg: #ffecb3;
+    --follow-onclick-border: #ffbf00;
+    --follow-onclick-hover: rgba(255, 191, 0, 30%);
+    --follow-media-bg: #b3d6ff;
+    --follow-media-border: #006deb;
+    --follow-media-hover: rgba(0, 109, 235), 30%;
+    --follow-image-bg: #d6bff2;
+    --follow-image-border: #772ad5;
+    --follow-image-hover: rgba(119, 42, 213, 30%);
+    --follow-other-bg: #d5d8c7;
+    --follow-other-border: #aaa;
+    --follow-other-hover: #aaa7;
 }
 
 /* general */

--- a/app/colors/paper-compact.css
+++ b/app/colors/paper-compact.css
@@ -1,0 +1,145 @@
+/*
+* Vieb - Vim Inspired Electron Browser
+* Copyright (C) 2020-2022 Jelmer van Arnhem
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*
+* ********************************************************************
+*
+*
+* The vieb-paper theme, developed c/o Samuel Sinclair
+* Original 'paper' theme and palette by Yorick Peterse
+* Source: https://gitlab.com/yorickpeterse/vim-paper
+*
+* Compact Version
+* Originally created by Stev (https://github.com/stevkazt)
+* Source: https://github.com/Jelmerro/Vieb/pull/374
+*
+*
+* ********************************************************************
+*
+*/
+/* colors */
+:root {
+    /* general */
+    --bg: #F2EEDE;
+    --fg: #000;
+    --tab-background: #F2EEDE;
+    --tab-suspended: #AAA;
+    --visible-tab: #D8D5C7;
+    --tab-crashed: #CC3E28;
+    --mode-normal-fg: #000;
+    --mode-insert-fg: #216609;
+    --mode-explore-fg: #158c86;
+    --mode-search-fg: #B58900;
+    --mode-follow-fg: #5C21A5;
+    --mode-command-fg: #CC3E28;
+    --mode-pointer-fg: #1E6FCC;
+    --mode-pointer-bg: #F2EEDE;
+    --mode-visual-fg: #1E6FCC;
+    --mode-visual-bg: #F2EEDE;
+    --helppage-range-compat: #000;
+    --helppage-h1: #000;
+    --helppage-h2: #000;
+    --helppage-h3: #000;
+    --helppage-h4: #000;
+    --helppage-h5: #000;
+    --helppage-h6: #000;
+    --url-default: #F2EEDE;
+    --url-search: #D8D5C7;
+    --url-searchwords: #5C21A5;
+    --url-url: #1E6FCC;
+    --url-suggest: #216609;
+    --url-file: #CC3E28;
+    --suggestions-border: #D8D5C7;
+    --suggestions-bg: #F2EEDE;
+    --suggestions-selected: #D8D5C7;
+    --suggestions-url: #1E6FCC;
+    --suggestions-file: #CC3E28;
+    --notification-border: #D8D5C7;
+    --notification-date: #000;
+    --notification-permission: #000;
+    --notification-error: #CC3E28;
+    --notification-warning: #CC3E28;
+    --notification-info: #1E6FCC;
+    --notification-success: #216609;
+    /* special pages */
+    --link-color: #1E6FCC;
+    --link-underline: #1E6FCC;
+    --scrollbar-bg: #F2EEDE;
+    --scrollbar-thumb: #D8D5C7;
+    --button-disabled: #AAA;
+    --code-fg: #000;
+    --code-bg: #D8D5C7;
+    --code-command: #000;
+    --special-page-element-bg: #F2EEDE;
+    --special-page-element-border: #D8D5C7;
+    --input-unfocused: #D8D5C7;
+    --input-focused: #000;
+    --download-progress-fg: #000;
+    --download-progress-bg: #D8D5C7;
+    --helppage-countable: #216609;
+    /* sourceviewer */
+    --syntax-keyword: #CC3E28;
+    --syntax-entity: #74c;
+    --syntax-constant: #06c;
+    --syntax-string: #036;
+    --syntax-variable: #e60;
+    --syntax-comment: #777;
+    --syntax-entity-tag: #284;
+    --syntax-markup-heading: #06c;
+    --syntax-markup-list: #760;
+    --syntax-markup-emphasis: #233;
+    --syntax-markup-addition-fg: #284;
+    --syntax-markup-addition-bg: #efe;
+    --syntax-markup-deletion-fg: #b22;
+    --syntax-markup-deletion-bg: #fee;
+    /* fine tuning */
+    --follow-text: #000;
+    --follow-url-bg: #bff;
+    --follow-url-border: #7dd;
+    --follow-url-hover: #7dd7;
+    --follow-click-bg: #fbb;
+    --follow-click-border: #d77;
+    --follow-click-hover: #d777;
+    --follow-insert-bg: #bfb;
+    --follow-insert-border: #7d7;
+    --follow-insert-hover: #7d77;
+    --follow-onclick-bg: #ffb;
+    --follow-onclick-border: #dd7;
+    --follow-onclick-hover: #dd77;
+    --follow-media-bg: #bbf;
+    --follow-media-border: #77d;
+    --follow-media-hover: #77d7;
+    --follow-image-bg: #fbf;
+    --follow-image-border: #d7d;
+    --follow-image-hover: #d7d7;
+    --follow-other-bg: #ddd;
+    --follow-other-border: #bbb;
+    --follow-other-hover: #bbb7;
+}
+
+/* general */
+#tabs .status {filter: invert(.4);}
+
+/* special pages */
+#app #pointer, #cookiespage img, #downloadspage img, #historypage img {filter: invert(1);}
+.specialpage a::after {filter: invert(1);}
+#helppage .cheatsheet {filter: none;}
+#historypage img.favicon {filter: none;}
+
+/* compact mode */
+#app {display: grid;grid-template: "navbar tabbar" 2em "main main" auto;}
+#navbar, #tabs {width: 50vw}
+#page-container{grid-area: main;}

--- a/app/colors/paper.css
+++ b/app/colors/paper.css
@@ -1,0 +1,136 @@
+/*
+* Vieb - Vim Inspired Electron Browser
+* Copyright (C) 2020-2022 Jelmer van Arnhem
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*
+* ********************************************************************
+*
+*
+* The vieb-paper theme, developed c/o Samuel Sinclair
+* Original 'paper' theme and palette by Yorick Peterse
+* Source: https://gitlab.com/yorickpeterse/vim-paper
+*
+*
+* ********************************************************************
+*
+*/
+/* colors */
+:root {
+    /* general */
+    --bg: #F2EEDE;
+    --fg: #000;
+    --tab-background: #F2EEDE;
+    --tab-suspended: #AAA;
+    --visible-tab: #D8D5C7;
+    --tab-crashed: #CC3E28;
+    --mode-normal-fg: #000;
+    --mode-insert-fg: #216609;
+    --mode-explore-fg: #158c86;
+    --mode-search-fg: #B58900;
+    --mode-follow-fg: #5C21A5;
+    --mode-command-fg: #CC3E28;
+    --mode-pointer-fg: #1E6FCC;
+    --mode-pointer-bg: #F2EEDE;
+    --mode-visual-fg: #1E6FCC;
+    --mode-visual-bg: #F2EEDE;
+    --helppage-range-compat: #000;
+    --helppage-h1: #000;
+    --helppage-h2: #000;
+    --helppage-h3: #000;
+    --helppage-h4: #000;
+    --helppage-h5: #000;
+    --helppage-h6: #000;
+    --url-default: #F2EEDE;
+    --url-search: #D8D5C7;
+    --url-searchwords: #5C21A5;
+    --url-url: #1E6FCC;
+    --url-suggest: #216609;
+    --url-file: #CC3E28;
+    --suggestions-border: #D8D5C7;
+    --suggestions-bg: #F2EEDE;
+    --suggestions-selected: #D8D5C7;
+    --suggestions-url: #1E6FCC;
+    --suggestions-file: #CC3E28;
+    --notification-border: #D8D5C7;
+    --notification-date: #000;
+    --notification-permission: #000;
+    --notification-error: #CC3E28;
+    --notification-warning: #CC3E28;
+    --notification-info: #1E6FCC;
+    --notification-success: #216609;
+    /* special pages */
+    --link-color: #1E6FCC;
+    --link-underline: #1E6FCC;
+    --scrollbar-bg: #F2EEDE;
+    --scrollbar-thumb: #D8D5C7;
+    --button-disabled: #AAA;
+    --code-fg: #000;
+    --code-bg: #D8D5C7;
+    --code-command: #000;
+    --special-page-element-bg: #F2EEDE;
+    --special-page-element-border: #D8D5C7;
+    --input-unfocused: #D8D5C7;
+    --input-focused: #000;
+    --download-progress-fg: #000;
+    --download-progress-bg: #D8D5C7;
+    --helppage-countable: #216609;
+    /* sourceviewer */
+    --syntax-keyword: #CC3E28;
+    --syntax-entity: #74c;
+    --syntax-constant: #06c;
+    --syntax-string: #036;
+    --syntax-variable: #e60;
+    --syntax-comment: #777;
+    --syntax-entity-tag: #284;
+    --syntax-markup-heading: #06c;
+    --syntax-markup-list: #760;
+    --syntax-markup-emphasis: #233;
+    --syntax-markup-addition-fg: #284;
+    --syntax-markup-addition-bg: #efe;
+    --syntax-markup-deletion-fg: #b22;
+    --syntax-markup-deletion-bg: #fee;
+    /* fine tuning */
+    --follow-text: #000;
+    --follow-url-bg: #bff;
+    --follow-url-border: #7dd;
+    --follow-url-hover: #7dd7;
+    --follow-click-bg: #fbb;
+    --follow-click-border: #d77;
+    --follow-click-hover: #d777;
+    --follow-insert-bg: #bfb;
+    --follow-insert-border: #7d7;
+    --follow-insert-hover: #7d77;
+    --follow-onclick-bg: #ffb;
+    --follow-onclick-border: #dd7;
+    --follow-onclick-hover: #dd77;
+    --follow-media-bg: #bbf;
+    --follow-media-border: #77d;
+    --follow-media-hover: #77d7;
+    --follow-image-bg: #fbf;
+    --follow-image-border: #d7d;
+    --follow-image-hover: #d7d7;
+    --follow-other-bg: #ddd;
+    --follow-other-border: #bbb;
+    --follow-other-hover: #bbb7;
+}
+
+/* general */
+#tabs .status {filter: invert(.4);}
+
+/* special pages */
+#app #pointer, #cookiespage img, #downloadspage img, #historypage img {filter: invert(1);}
+.specialpage a::after {filter: invert(1);}
+#helppage .cheatsheet {filter: none;}
+#historypage img.favicon {filter: none;}

--- a/app/colors/paper.css
+++ b/app/colors/paper.css
@@ -87,7 +87,7 @@
     --download-progress-bg: #D8D5C7;
     --helppage-countable: #216609;
     /* sourceviewer */
-    --syntax-keyword: #CC3E28;
+    --syntax-keyword: #d45;
     --syntax-entity: #74c;
     --syntax-constant: #06c;
     --syntax-string: #036;
@@ -101,29 +101,29 @@
     --syntax-markup-addition-bg: #efe;
     --syntax-markup-deletion-fg: #b22;
     --syntax-markup-deletion-bg: #fee;
-    /* fine tuning */
+    /* fine tuning follow-links */
     --follow-text: #000;
-    --follow-url-bg: #bff;
-    --follow-url-border: #7dd;
-    --follow-url-hover: #7dd7;
+    --follow-url-bg: #bcf5f2;
+    --follow-url-border: #21ded4;
+    --follow-url-hover: rgba(33, 222, 212, 30%);
     --follow-click-bg: #fbb;
-    --follow-click-border: #d77;
-    --follow-click-hover: #d777;
-    --follow-insert-bg: #bfb;
-    --follow-insert-border: #7d7;
-    --follow-insert-hover: #7d77;
-    --follow-onclick-bg: #ffb;
-    --follow-onclick-border: #dd7;
-    --follow-onclick-hover: #dd77;
-    --follow-media-bg: #bbf;
-    --follow-media-border: #77d;
-    --follow-media-hover: #77d7;
-    --follow-image-bg: #fbf;
-    --follow-image-border: #d7d;
-    --follow-image-hover: #d7d7;
-    --follow-other-bg: #ddd;
-    --follow-other-border: #bbb;
-    --follow-other-hover: #bbb7;
+    --follow-click-border: #e92a0c;
+    --follow-click-hover: rgba(233, 42, 12, 30%);
+    --follow-insert-bg: #c9f9b9;
+    --follow-insert-border: #4aeb14;
+    --follow-insert-hover: rgba(74, 235, 20, 30%);
+    --follow-onclick-bg: #ffecb3;
+    --follow-onclick-border: #ffbf00;
+    --follow-onclick-hover: rgba(255, 191, 0, 30%);
+    --follow-media-bg: #b3d6ff;
+    --follow-media-border: #006deb;
+    --follow-media-hover: rgba(0, 109, 235), 30%;
+    --follow-image-bg: #d6bff2;
+    --follow-image-border: #772ad5;
+    --follow-image-hover: rgba(119, 42, 213, 30%);
+    --follow-other-bg: #d5d8c7;
+    --follow-other-border: #aaa;
+    --follow-other-hover: #aaa7;
 }
 
 /* general */


### PR DESCRIPTION
Hi Jelmer,

I hope you're well. Thanks very much for your continued work on Vieb, the latest ad-block list update has been fantastic.

Spent a bit of time today working on a (gasp) light theme using the 'vim-paper' palette, designed by @YorickPeterse, and includes a compact version. I've also included the compact theme coding to the default light theme so users have a choice if they wish. 

Here's a gif showing the design. Note that I have not changed any of the follow-mode linking colours yet as I'm still experimenting with the paper palette and it's usability across a range of websites.

![vieb-paper-demo](https://user-images.githubusercontent.com/68577322/190580629-bf342a52-4513-4ab5-93a8-4be4265908cd.gif)

Cheers,

Sam
