### PR TITLE
Fix: cant write to disk erwic settings that match defaultSettings

### DIFF
--- a/app/renderer/settings.js
+++ b/app/renderer/settings.js
@@ -1299,16 +1299,17 @@ const loadFromDisk = (firstRun = true) => {
         validOptions.adblocker = ["off"]
     }
     if (firstRun) {
+        if (isFile(joinPath(appData(), "erwicmode"))) {
+            defaultSettings.containernewtab = "s:external"
+            defaultSettings.containerstartuppage = "s:usematching"
+            defaultSettings.permissioncamera = "s:allow"
+            defaultSettings.permissionnotifications = "s:allow"
+            defaultSettings.permissionmediadevices = "s:allowfull"
+            defaultSettings.permissionmicrophone = "s:allow"
+        }
+
         allSettings = JSON.parse(JSON.stringify(defaultSettings))
         sessionStorage.setItem("settings", JSON.stringify(allSettings))
-    }
-    if (isFile(joinPath(appData(), "erwicmode"))) {
-        set("containernewtab", "s:external")
-        set("containerstartuppage", "s:usematching")
-        set("permissioncamera", "allow")
-        set("permissionnotifications", "allow")
-        set("permissionmediadevices", "allowfull")
-        set("permissionmicrophone", "allow")
     }
     for (const conf of files) {
         if (isFile(conf)) {

--- a/app/renderer/settings.js
+++ b/app/renderer/settings.js
@@ -1299,17 +1299,16 @@ const loadFromDisk = (firstRun = true) => {
         validOptions.adblocker = ["off"]
     }
     if (firstRun) {
-        if (isFile(joinPath(appData(), "erwicmode"))) {
-            defaultSettings.containernewtab = "s:external"
-            defaultSettings.containerstartuppage = "s:usematching"
-            defaultSettings.permissioncamera = "s:allow"
-            defaultSettings.permissionnotifications = "s:allow"
-            defaultSettings.permissionmediadevices = "s:allowfull"
-            defaultSettings.permissionmicrophone = "s:allow"
-        }
-
         allSettings = JSON.parse(JSON.stringify(defaultSettings))
         sessionStorage.setItem("settings", JSON.stringify(allSettings))
+    }
+    if (isFile(joinPath(appData(), "erwicmode"))) {
+        set("containernewtab", "s:external")
+        set("containerstartuppage", "s:usematching")
+        set("permissioncamera", "allow")
+        set("permissionnotifications", "allow")
+        set("permissionmediadevices", "allowfull")
+        set("permissionmicrophone", "allow")
     }
     for (const conf of files) {
         if (isFile(conf)) {

--- a/app/renderer/settings.js
+++ b/app/renderer/settings.js
@@ -242,6 +242,16 @@ const defaultSettings = {
     "vimcommand": "gvim",
     "windowtitle": "%app - %title"
 }
+const defaultErwicSettings = {
+    "containernewtab": "s:external",
+    "containerstartuppage": "s:usematching",
+    "permissioncamera": "allow",
+    "permissionmediadevices": "allowfull",
+    "permissionmicrophone": "allow",
+    "permissionnotifications": "allow"
+}
+
+
 let allSettings = {}
 const freeText = [
     "downloadpath",
@@ -1303,12 +1313,10 @@ const loadFromDisk = (firstRun = true) => {
         sessionStorage.setItem("settings", JSON.stringify(allSettings))
     }
     if (isFile(joinPath(appData(), "erwicmode"))) {
-        set("containernewtab", "s:external")
-        set("containerstartuppage", "s:usematching")
-        set("permissioncamera", "allow")
-        set("permissionnotifications", "allow")
-        set("permissionmediadevices", "allowfull")
-        set("permissionmicrophone", "allow")
+        const erwicDefaults = JSON.parse(JSON.stringify(defaultErwicSettings))
+        Object.keys(erwicDefaults).forEach(t => {
+            set(t, erwicDefaults[t])
+        })
     }
     for (const conf of files) {
         if (isFile(conf)) {
@@ -1611,6 +1619,13 @@ const listCurrentSettings = full => {
     const settings = JSON.parse(JSON.stringify(allSettings))
     if (!full) {
         const defaults = JSON.parse(JSON.stringify(defaultSettings))
+        if (isFile(joinPath(appData(), "erwicmode"))) {
+            const erwicDefaults = JSON.parse(
+                JSON.stringify(defaultErwicSettings)
+            )
+            Object.assign(defaults, erwicDefaults)
+        }
+
         Object.keys(settings).forEach(t => {
             if (JSON.stringify(settings[t]) === JSON.stringify(defaults[t])) {
                 delete settings[t]


### PR DESCRIPTION
`defaultSettings` has for example `containernewtab` set to `s:usecurrent`, and when running an erwic application the setting is set to `s:external`, but when trying to set it back to `s:usecurrent` and running `mkviebrc` to write to disk, the setting can't be saved as it still matches the `defaultSettings` default, so erwic applications will always run overriding these settings that can't be saved. This change instead replaces the `defaultSettings` value when running an erwic application, and then allowing that setting to be written to disk when changed as it won't match the new defaults