### PR TITLE
use absolute path for RSS feeds

### DIFF
--- a/app/renderer/actions.js
+++ b/app/renderer/actions.js
@@ -967,7 +967,14 @@ const getPageRSSLinks = async() => {
         notify("No RSS feeds found on this page", "warn")
         return null
     }
-    return feedUrls.slice(0, 10).map(getPageUrl)
+    return feedUrls.slice(0, 10).map((feed = "") => {
+        // If the feed URL's path is relative, make it absolute.
+        if (feed.startsWith("/")) {
+            const pageOrigin = new URL(getPageUrl()).origin
+            return getPageUrl(`${pageOrigin}${feed}`)
+        }
+        return getPageUrl(feed)
+    })
 }
 
 const pageRSSLinksList = async() => {


### PR DESCRIPTION
Turns this:
![image](https://github.com/Jelmerro/Vieb/assets/76502841/76d64a02-4935-48b8-95ba-20e01318ac61)
into this:
![image](https://github.com/Jelmerro/Vieb/assets/76502841/b3cf5644-393f-42fe-b038-6d1c4d3d3c33)
otherwise copies only the path and not the full link

_(example taken from https://invidious.sethforprivacy.com/channel/UCl2mFZoRqjw_ELax4Yisf6w)_