### PR TITLE
Fix media-playing indicator in numberedtabs colorscheme

### DIFF
--- a/app/colors/numberedtabs.css
+++ b/app/colors/numberedtabs.css
@@ -17,5 +17,5 @@
 */
 #tabs, #navbar {counter-reset: tab-counter -1;}
 #tabs > ::before {counter-increment: tab-counter 1;content: counter(tab-counter) ". ";margin: auto 0;}
-#tabs [media-playing]::before {margin: 0 !important}
+#tabs [media-playing]::before {margin: 0 !important;}
 #tabs .pinned {min-width: 3em !important;}

--- a/app/colors/numberedtabs.css
+++ b/app/colors/numberedtabs.css
@@ -17,4 +17,5 @@
 */
 #tabs, #navbar {counter-reset: tab-counter -1;}
 #tabs > ::before {counter-increment: tab-counter 1;content: counter(tab-counter) ". ";margin: auto 0;}
+#tabs [media-playing]::before {margin: 0 !important}
 #tabs .pinned {min-width: 3em !important;}


### PR DESCRIPTION
the auto margin was causing the media-playing indicator to be hidden. I didn't even notice for a long time that was missing