### PR TITLE
Fix Typo

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -230,7 +230,7 @@
             "external": "External",
             "go": "Go",
             "navigate": "Navigate",
-            "newtab": "Newtab",
+            "newtab": "New tab",
             "search": "Search",
             "split": "Split",
             "vsplit": "Vsplit"
@@ -357,7 +357,7 @@
         },
         "newtab": {
             "favorites": "Favorites",
-            "title": "Newtab",
+            "title": "New tab",
             "topsites": "Top sites"
         },
         "notifications": {


### PR DESCRIPTION
On Firefox It's "New Tab"
On Chrome It's "New tab"
in app/pages/newtab.html It's "New tab" so that settles it. P.S: Leads to weird loading behavior where the original name "newtab' is shown without an icon before the page is loaded  I'm on slow hardware so this might not be as big of of a problem as it might seem.