### PR TITLE
fix dom overload

### DIFF
--- a/app/preload/follow.js
+++ b/app/preload/follow.js
@@ -90,15 +90,8 @@ const hasContextMenuListener = el => {
     if (hasAttribute) {
         return true
     }
-    /** @type {{[type: string]: number}} */
-    const listeners = {}
-    const attr = el.getAttribute("data-eventlisteners")
-    for (const l of attr?.split(",") ?? []) {
-        const [name, countStr] = l.split(":")
-        const count = Number(countStr) || 0
-        listeners[name] = count
-    }
-    return listeners.contextmenu && listeners.contextmenu > 0
+    const counts = window.getEventListenerCount?.(el) || {};
+    return counts?.contextmenu && counts.contextmenu > 0
 }
 
 /**
@@ -135,19 +128,12 @@ const elementsWithMouseListeners = els => contextBridge.executeInMainWorld({
                 // @ts-expect-error Reduce types are broken in TS.
                 elementsWithListeners.push({el, "type": "other"})
             }
-            /** @type {{[type: string]: number}} */
-            const listeners = {}
-            const attr = el.getAttribute("data-eventlisteners")
-            for (const l of attr?.split(",") ?? []) {
-                const [name, countStr] = l.split(":")
-                const count = Number(countStr) || 0
-                listeners[name] = count
-            }
-            if (clickEvents.some(t => listeners[t] && listeners[t] > 0)) {
+            const counts = window.getEventListenerCount?.(el) || {};
+            if (clickEvents.some(t => counts[t] && counts[t] > 0)) {
                 // @ts-expect-error Reduce types are broken in TS.
                 elementsWithListeners.push({el, "type": "onclick"})
             }
-            if (otherEvents.some(t => listeners[t] && listeners[t] > 0)) {
+            if (otherEvents.some(t => counts[t] && counts[t] > 0)) {
                 // @ts-expect-error Reduce types are broken in TS.
                 elementsWithListeners.push({el, "type": "other"})
             }
@@ -438,6 +424,8 @@ const trackEventListeners = () => {
             }
         }
     };
+
+    window.getEventListenerCount = el => listenerCounts.get(el) || {};
 };
 
 contextBridge.executeInMainWorld({"func": trackEventListeners})


### PR DESCRIPTION
**Problem description:**
I tested YouTube in Vieb and confirmed that this is not an Electron issue. On versions **38.0.0** and **39.0.0** using Electron Fiddle, YouTube loads and works fine:

`mainWindow.loadURL('https://youtube.com')`

**What I did:**
Disabled Vieb modules one by one.

After disabling follow.js, YouTube started working correctly.

Found that the `trackEventListeners` function overloads the DOM: it writes data about every event listener to the data-eventlisteners attribute, causing constant updates and potentially triggering **MaxListenersExceededWarning**.

Note: I am not a frontend developer and had no prior experience with Electron; the solution is based on ChatGPT guidance and my own testing.

**Solution:**
Instead of writing to the DOM, I used a WeakMap to store listener data.

This reduces memory pressure and prevents leaks while keeping the event tracking functionality intact.

**Result:**
YouTube works correctly.

No more warnings about exceeding the maximum number of listeners.

<img width="1587" height="856" alt="изображение" src="https://github.com/user-attachments/assets/180f5252-6657-4ed6-9324-98e610bdf175" />