### PR TITLE
feat(theme): add new light/dark variants and make default themes follow system color scheme

### DIFF
--- a/app/colors/dark-compact.css
+++ b/app/colors/dark-compact.css
@@ -1,0 +1,91 @@
+/*
+* Vieb - Vim Inspired Electron Browser
+* Copyright (C) 2022-2025 Jelmer van Arnhem
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+:root {
+    /* general */
+    --bg: #333;
+    --fg: #eee;
+    --tab-background: #444;
+    --tab-suspended: #000;
+    --visible-tab: #666;
+    --tab-crashed: #f00;
+    --mode-normal-fg: #eee;
+    --mode-insert-fg: #3f3;
+    --mode-explore-fg: #3ff;
+    --mode-search-fg: #ff3;
+    --url-default: #666;
+    --url-search: #f90;
+    --url-searchwords: #fcf;
+    --url-url: #3ff;
+    --url-suggest: #3f3;
+    --url-file: #ff9;
+    --suggestions-border: #777;
+    --suggestions-bg: #444;
+    --suggestions-selected: #666;
+    --suggestions-url: #bff;
+    --suggestions-file: #ffb;
+    --notification-border: #111;
+    --notification-date: #aaa;
+    --notification-permission: #aaa;
+    --notification-error: #f33;
+    --notification-warning: #fd0;
+    --notification-info: #0cf;
+    --notification-success: #3f3;
+    /* special pages */
+    --link-color: #0cf;
+    --link-underline: #059;
+    --scrollbar-bg: #444;
+    --scrollbar-thumb: #bbb9;
+    --button-disabled: #999;
+    --code-fg: #fff;
+    --code-bg: #111;
+    --special-page-element-bg: #444;
+    --special-page-element-border: #222;
+    --input-unfocused: #666;
+    --input-focused: #aaa;
+    --download-progress-fg: #ccc;
+    --download-progress-bg: #666;
+    --helppage-countable: #fc0;
+    /* sourceviewer */
+    --syntax-keyword: #f77;
+    --syntax-entity: #daf;
+    --syntax-constant: #8cf;
+    --syntax-string: #adf;
+    --syntax-variable: #fa5;
+    --syntax-comment: #89a;
+    --syntax-entity-tag: #8e8;
+    --syntax-markup-heading: #27e;
+    --syntax-markup-list: #fc6;
+    --syntax-markup-emphasis: #cde;
+    --syntax-markup-addition-fg: #bfb;
+    --syntax-markup-addition-bg: #041;
+    --syntax-markup-deletion-fg: #fdd;
+    --syntax-markup-deletion-bg: #600;
+}
+
+/* general */
+#tabs .status {filter: none;}
+
+/* special pages */
+#app #pointer, #cookiespage img, #downloadspage img, #historypage img {filter: none;}
+.specialpage a::after {filter: none;}
+#helppage .cheatsheet {filter: filter: contrast(.5) invert() contrast(4) hue-rotate(180deg) saturate(4);}
+
+/* compact */
+#app {display: grid;grid-template: "navbar tabbar" 2em "main main" auto;}
+#navbar, #tabs {width: 50vw}
+#page-container {grid-area: main;}

--- a/app/colors/dark-flipped.css
+++ b/app/colors/dark-flipped.css
@@ -1,0 +1,96 @@
+/*
+* Vieb - Vim Inspired Electron Browser
+* Copyright (C) 2020-2025 Jelmer van Arnhem
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+:root {
+    /* general */
+    --bg: #333;
+    --fg: #eee;
+    --tab-background: #444;
+    --tab-suspended: #000;
+    --visible-tab: #666;
+    --tab-crashed: #f00;
+    --mode-normal-fg: #eee;
+    --mode-insert-fg: #3f3;
+    --mode-explore-fg: #3ff;
+    --mode-search-fg: #ff3;
+    --url-default: #666;
+    --url-search: #f90;
+    --url-searchwords: #fcf;
+    --url-url: #3ff;
+    --url-suggest: #3f3;
+    --url-file: #ff9;
+    --suggestions-border: #777;
+    --suggestions-bg: #444;
+    --suggestions-selected: #666;
+    --suggestions-url: #bff;
+    --suggestions-file: #ffb;
+    --notification-border: #111;
+    --notification-date: #aaa;
+    --notification-permission: #aaa;
+    --notification-error: #f33;
+    --notification-warning: #fd0;
+    --notification-info: #0cf;
+    --notification-success: #3f3;
+    /* special pages */
+    --link-color: #0cf;
+    --link-underline: #059;
+    --scrollbar-bg: #444;
+    --scrollbar-thumb: #bbb9;
+    --button-disabled: #999;
+    --code-fg: #fff;
+    --code-bg: #111;
+    --special-page-element-bg: #444;
+    --special-page-element-border: #222;
+    --input-unfocused: #666;
+    --input-focused: #aaa;
+    --download-progress-fg: #ccc;
+    --download-progress-bg: #666;
+    --helppage-countable: #fc0;
+    /* sourceviewer */
+    --syntax-keyword: #f77;
+    --syntax-entity: #daf;
+    --syntax-constant: #8cf;
+    --syntax-string: #adf;
+    --syntax-variable: #fa5;
+    --syntax-comment: #89a;
+    --syntax-entity-tag: #8e8;
+    --syntax-markup-heading: #27e;
+    --syntax-markup-list: #fc6;
+    --syntax-markup-emphasis: #cde;
+    --syntax-markup-addition-fg: #bfb;
+    --syntax-markup-addition-bg: #041;
+    --syntax-markup-deletion-fg: #fdd;
+    --syntax-markup-deletion-bg: #600;
+}
+
+/* general */
+#tabs .status {filter: none;}
+
+/* special pages */
+#app #pointer, #cookiespage img, #downloadspage img, #historypage img {filter: none;}
+.specialpage a::after {filter: none;}
+#helppage .cheatsheet {filter: filter: contrast(.5) invert() contrast(4) hue-rotate(180deg) saturate(4);}
+
+/* general */
+#app {flex-direction: column-reverse;}
+#url-hover {bottom: 4em;}
+#suggest-dropdown {top: auto;bottom: .1em;flex-direction: column-reverse;}
+#mode-suggestions {top: auto;bottom: 1.9em;flex-direction: column-reverse;}
+/* hidden bars */
+#app.tabshidden #url-hover, #app.navigationhidden #url-hover {bottom: 2em;}
+#app.tabshidden.navigationhidden #url-hover {bottom: 0;}
+#app.navigationhidden #suggest-dropdown {top: auto;bottom: .1em;}

--- a/app/colors/dark-numberedtabs.css
+++ b/app/colors/dark-numberedtabs.css
@@ -1,0 +1,91 @@
+/*
+* Vieb - Vim Inspired Electron Browser
+* Copyright (C) 2022-2025 Jelmer van Arnhem
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+:root {
+    /* general */
+    --bg: #333;
+    --fg: #eee;
+    --tab-background: #444;
+    --tab-suspended: #000;
+    --visible-tab: #666;
+    --tab-crashed: #f00;
+    --mode-normal-fg: #eee;
+    --mode-insert-fg: #3f3;
+    --mode-explore-fg: #3ff;
+    --mode-search-fg: #ff3;
+    --url-default: #666;
+    --url-search: #f90;
+    --url-searchwords: #fcf;
+    --url-url: #3ff;
+    --url-suggest: #3f3;
+    --url-file: #ff9;
+    --suggestions-border: #777;
+    --suggestions-bg: #444;
+    --suggestions-selected: #666;
+    --suggestions-url: #bff;
+    --suggestions-file: #ffb;
+    --notification-border: #111;
+    --notification-date: #aaa;
+    --notification-permission: #aaa;
+    --notification-error: #f33;
+    --notification-warning: #fd0;
+    --notification-info: #0cf;
+    --notification-success: #3f3;
+    /* special pages */
+    --link-color: #0cf;
+    --link-underline: #059;
+    --scrollbar-bg: #444;
+    --scrollbar-thumb: #bbb9;
+    --button-disabled: #999;
+    --code-fg: #fff;
+    --code-bg: #111;
+    --special-page-element-bg: #444;
+    --special-page-element-border: #222;
+    --input-unfocused: #666;
+    --input-focused: #aaa;
+    --download-progress-fg: #ccc;
+    --download-progress-bg: #666;
+    --helppage-countable: #fc0;
+    /* sourceviewer */
+    --syntax-keyword: #f77;
+    --syntax-entity: #daf;
+    --syntax-constant: #8cf;
+    --syntax-string: #adf;
+    --syntax-variable: #fa5;
+    --syntax-comment: #89a;
+    --syntax-entity-tag: #8e8;
+    --syntax-markup-heading: #27e;
+    --syntax-markup-list: #fc6;
+    --syntax-markup-emphasis: #cde;
+    --syntax-markup-addition-fg: #bfb;
+    --syntax-markup-addition-bg: #041;
+    --syntax-markup-deletion-fg: #fdd;
+    --syntax-markup-deletion-bg: #600;
+}
+
+/* general */
+#tabs .status {filter: none;}
+
+/* special pages */
+#app #pointer, #cookiespage img, #downloadspage img, #historypage img {filter: none;}
+.specialpage a::after {filter: none;}
+#helppage .cheatsheet {filter: filter: contrast(.5) invert() contrast(4) hue-rotate(180deg) saturate(4);}
+
+#tabs, #navbar {counter-reset: tab-counter -1;}
+#tabs > ::before {counter-increment: tab-counter 1;content: counter(tab-counter) ". ";margin: auto 0;}
+#tabs [media-playing]::before {margin: 0 !important;}
+#tabs .pinned {min-width: 3em !important;}

--- a/app/colors/dark-verticaltabs.css
+++ b/app/colors/dark-verticaltabs.css
@@ -1,0 +1,96 @@
+/*
+* Vieb - Vim Inspired Electron Browser
+* Copyright (C) 2020-2025 Jelmer van Arnhem
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+:root {
+    /* general */
+    --bg: #333;
+    --fg: #eee;
+    --tab-background: #444;
+    --tab-suspended: #000;
+    --visible-tab: #666;
+    --tab-crashed: #f00;
+    --mode-normal-fg: #eee;
+    --mode-insert-fg: #3f3;
+    --mode-explore-fg: #3ff;
+    --mode-search-fg: #ff3;
+    --url-default: #666;
+    --url-search: #f90;
+    --url-searchwords: #fcf;
+    --url-url: #3ff;
+    --url-suggest: #3f3;
+    --url-file: #ff9;
+    --suggestions-border: #777;
+    --suggestions-bg: #444;
+    --suggestions-selected: #666;
+    --suggestions-url: #bff;
+    --suggestions-file: #ffb;
+    --notification-border: #111;
+    --notification-date: #aaa;
+    --notification-permission: #aaa;
+    --notification-error: #f33;
+    --notification-warning: #fd0;
+    --notification-info: #0cf;
+    --notification-success: #3f3;
+    /* special pages */
+    --link-color: #0cf;
+    --link-underline: #059;
+    --scrollbar-bg: #444;
+    --scrollbar-thumb: #bbb9;
+    --button-disabled: #999;
+    --code-fg: #fff;
+    --code-bg: #111;
+    --special-page-element-bg: #444;
+    --special-page-element-border: #222;
+    --input-unfocused: #666;
+    --input-focused: #aaa;
+    --download-progress-fg: #ccc;
+    --download-progress-bg: #666;
+    --helppage-countable: #fc0;
+    /* sourceviewer */
+    --syntax-keyword: #f77;
+    --syntax-entity: #daf;
+    --syntax-constant: #8cf;
+    --syntax-string: #adf;
+    --syntax-variable: #fa5;
+    --syntax-comment: #89a;
+    --syntax-entity-tag: #8e8;
+    --syntax-markup-heading: #27e;
+    --syntax-markup-list: #fc6;
+    --syntax-markup-emphasis: #cde;
+    --syntax-markup-addition-fg: #bfb;
+    --syntax-markup-addition-bg: #041;
+    --syntax-markup-deletion-fg: #fdd;
+    --syntax-markup-deletion-bg: #600;
+}
+
+/* general */
+#tabs .status {filter: none;}
+
+/* special pages */
+#app #pointer, #cookiespage img, #downloadspage img, #historypage img {filter: none;}
+.specialpage a::after {filter: none;}
+#helppage .cheatsheet {filter: filter: contrast(.5) invert() contrast(4) hue-rotate(180deg) saturate(4);}
+
+/* vertical tabs */
+#tabs {overflow-x: hidden;overflow-y: auto;position: absolute;left: 0;width: 15vw;max-height: calc(100vh - 2em);top: 2em;flex-wrap: wrap;}
+#tabs > span {min-height: 1.9em;max-height: 1.9em;min-width: 14vw !important;width: 15vw;}
+#page-container {height: calc(100vh - 2em);position: absolute;top: 2em;left: 15vw;width: 85vw;}
+#app.fullscreen #page-container {height: 100vh;width: 100vw;top: 0;left: 0;}
+#app.tabshidden #page-container {width: 100vw;left: 0;}
+#app.navigationhidden #page-container {height: 100vh;top: 0;}
+#app.navigationhidden #tabs {top: 0;max-height: 100vh;}
+#tabs::-webkit-scrollbar {width: .2em;height: auto;}

--- a/app/colors/dark-verticaltabsright.css
+++ b/app/colors/dark-verticaltabsright.css
@@ -1,0 +1,96 @@
+/*
+* Vieb - Vim Inspired Electron Browser
+* Copyright (C) 2020-2025 Jelmer van Arnhem
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+:root {
+    /* general */
+    --bg: #333;
+    --fg: #eee;
+    --tab-background: #444;
+    --tab-suspended: #000;
+    --visible-tab: #666;
+    --tab-crashed: #f00;
+    --mode-normal-fg: #eee;
+    --mode-insert-fg: #3f3;
+    --mode-explore-fg: #3ff;
+    --mode-search-fg: #ff3;
+    --url-default: #666;
+    --url-search: #f90;
+    --url-searchwords: #fcf;
+    --url-url: #3ff;
+    --url-suggest: #3f3;
+    --url-file: #ff9;
+    --suggestions-border: #777;
+    --suggestions-bg: #444;
+    --suggestions-selected: #666;
+    --suggestions-url: #bff;
+    --suggestions-file: #ffb;
+    --notification-border: #111;
+    --notification-date: #aaa;
+    --notification-permission: #aaa;
+    --notification-error: #f33;
+    --notification-warning: #fd0;
+    --notification-info: #0cf;
+    --notification-success: #3f3;
+    /* special pages */
+    --link-color: #0cf;
+    --link-underline: #059;
+    --scrollbar-bg: #444;
+    --scrollbar-thumb: #bbb9;
+    --button-disabled: #999;
+    --code-fg: #fff;
+    --code-bg: #111;
+    --special-page-element-bg: #444;
+    --special-page-element-border: #222;
+    --input-unfocused: #666;
+    --input-focused: #aaa;
+    --download-progress-fg: #ccc;
+    --download-progress-bg: #666;
+    --helppage-countable: #fc0;
+    /* sourceviewer */
+    --syntax-keyword: #f77;
+    --syntax-entity: #daf;
+    --syntax-constant: #8cf;
+    --syntax-string: #adf;
+    --syntax-variable: #fa5;
+    --syntax-comment: #89a;
+    --syntax-entity-tag: #8e8;
+    --syntax-markup-heading: #27e;
+    --syntax-markup-list: #fc6;
+    --syntax-markup-emphasis: #cde;
+    --syntax-markup-addition-fg: #bfb;
+    --syntax-markup-addition-bg: #041;
+    --syntax-markup-deletion-fg: #fdd;
+    --syntax-markup-deletion-bg: #600;
+}
+
+/* general */
+#tabs .status {filter: none;}
+
+/* special pages */
+#app #pointer, #cookiespage img, #downloadspage img, #historypage img {filter: none;}
+.specialpage a::after {filter: none;}
+#helppage .cheatsheet {filter: filter: contrast(.5) invert() contrast(4) hue-rotate(180deg) saturate(4);}
+
+/* vertical tabs right */
+#tabs {overflow-x: hidden;overflow-y: auto;position: absolute;right: 0;width: 15vw;max-height: calc(100vh - 2em);top: 2em;flex-wrap: wrap;}
+#tabs > span {min-height: 1.9em;max-height: 1.9em;min-width: 14vw !important;width: 15vw;}
+#page-container {height: calc(100vh - 2em);position: absolute;top: 2em;right: 15vw;width: 85vw;}
+#app.fullscreen #page-container {height: 100vh;width: 100vw;top: 0;left: 0;}
+#app.tabshidden #page-container {width: 100vw;right: 0;}
+#app.navigationhidden #page-container {height: 100vh;top: 0;}
+#app.navigationhidden #tabs {top: 0;max-height: 100vh;}
+#tabs::-webkit-scrollbar {width: .2em;height: auto;}

--- a/app/colors/dark.css
+++ b/app/colors/dark.css
@@ -1,0 +1,87 @@
+/*
+* Vieb - Vim Inspired Electron Browser
+* Copyright (C) 2019-2025 Jelmer van Arnhem
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+/* colors */
+:root {
+    /* general */
+    --bg: #333;
+    --fg: #eee;
+    --tab-background: #444;
+    --tab-suspended: #000;
+    --visible-tab: #666;
+    --tab-crashed: #f00;
+    --mode-normal-fg: #eee;
+    --mode-insert-fg: #3f3;
+    --mode-explore-fg: #3ff;
+    --mode-search-fg: #ff3;
+    --url-default: #666;
+    --url-search: #f90;
+    --url-searchwords: #fcf;
+    --url-url: #3ff;
+    --url-suggest: #3f3;
+    --url-file: #ff9;
+    --suggestions-border: #777;
+    --suggestions-bg: #444;
+    --suggestions-selected: #666;
+    --suggestions-url: #bff;
+    --suggestions-file: #ffb;
+    --notification-border: #111;
+    --notification-date: #aaa;
+    --notification-permission: #aaa;
+    --notification-error: #f33;
+    --notification-warning: #fd0;
+    --notification-info: #0cf;
+    --notification-success: #3f3;
+    /* special pages */
+    --link-color: #0cf;
+    --link-underline: #059;
+    --scrollbar-bg: #444;
+    --scrollbar-thumb: #bbb9;
+    --button-disabled: #999;
+    --code-fg: #fff;
+    --code-bg: #111;
+    --special-page-element-bg: #444;
+    --special-page-element-border: #222;
+    --input-unfocused: #666;
+    --input-focused: #aaa;
+    --download-progress-fg: #ccc;
+    --download-progress-bg: #666;
+    --helppage-countable: #fc0;
+    /* sourceviewer */
+    --syntax-keyword: #f77;
+    --syntax-entity: #daf;
+    --syntax-constant: #8cf;
+    --syntax-string: #adf;
+    --syntax-variable: #fa5;
+    --syntax-comment: #89a;
+    --syntax-entity-tag: #8e8;
+    --syntax-markup-heading: #27e;
+    --syntax-markup-list: #fc6;
+    --syntax-markup-emphasis: #cde;
+    --syntax-markup-addition-fg: #bfb;
+    --syntax-markup-addition-bg: #041;
+    --syntax-markup-deletion-fg: #fdd;
+    --syntax-markup-deletion-bg: #600;
+}
+
+/* general */
+#tabs .status {filter: none;}
+
+/* special pages */
+#app #pointer, #cookiespage img, #downloadspage img, #historypage img {filter: none;}
+.specialpage a::after {filter: none;}
+#helppage .cheatsheet {filter: filter: contrast(.5) invert() contrast(4) hue-rotate(180deg) saturate(4);}

--- a/app/colors/default.css
+++ b/app/colors/default.css
@@ -149,6 +149,80 @@
     --filebrowser-error: var(--notification-error);
 }
 
+/* light.css */
+@media (prefers-color-scheme: light) {
+    /* colors */
+    :root {
+        /* general */
+        --bg: #eee;
+        --fg: #333;
+        --tab-background: #ddd;
+        --tab-suspended: #777;
+        --visible-tab: #fff;
+        --tab-crashed: #faa;
+        --mode-normal-fg: #333;
+        --mode-insert-fg: #0c0;
+        --mode-explore-fg: #0cc;
+        --mode-search-fg: #fb0;
+        --url-default: #ddd;
+        --url-search: #f80;
+        --url-searchwords: #f5f;
+        --url-url: #08f;
+        --url-suggest: #0c0;
+        --url-file: #fb0;
+        --suggestions-border: #eee;
+        --suggestions-bg: #ddd;
+        --suggestions-selected: #fff;
+        --suggestions-url: #08f;
+        --suggestions-file: #f80;
+        --notification-border: #aaa;
+        --notification-date: #777;
+        --notification-permission: #777;
+        --notification-error: #f33;
+        --notification-warning: #f80;
+        --notification-info: #08f;
+        --notification-success: #0c0;
+        /* special pages */
+        --link-color: #08f;
+        --link-underline: #0df;
+        --scrollbar-bg: #fff;
+        --scrollbar-thumb: #aaa7;
+        --button-disabled: #777;
+        --code-fg: #000;
+        --code-bg: #fff;
+        --special-page-element-bg: #ddd;
+        --special-page-element-border: #aaa;
+        --input-unfocused: #aaa;
+        --input-focused: #666;
+        --download-progress-fg: #fff;
+        --download-progress-bg: #eee;
+        --helppage-countable: #0c0;
+        /* sourceviewer */
+        --syntax-keyword: #d45;
+        --syntax-entity: #74c;
+        --syntax-constant: #06c;
+        --syntax-string: #036;
+        --syntax-variable: #e60;
+        --syntax-comment: #777;
+        --syntax-entity-tag: #284;
+        --syntax-markup-heading: #06c;
+        --syntax-markup-list: #760;
+        --syntax-markup-emphasis: #233;
+        --syntax-markup-addition-fg: #284;
+        --syntax-markup-addition-bg: #efe;
+        --syntax-markup-deletion-fg: #b22;
+        --syntax-markup-deletion-bg: #fee;
+    }
+
+    /* general */
+    #tabs .status {filter: invert(.4);}
+
+    /* special pages */
+    #app #pointer, #cookiespage img, #downloadspage img, #historypage img {filter: invert(1);}
+    .specialpage a::after {filter: invert(1);}
+    #helppage .cheatsheet {filter: none;}
+    #historypage img.favicon {filter: none;}
+}
 
 /*
  * GLOBAL

--- a/app/colors/light-flipped.css
+++ b/app/colors/light-flipped.css
@@ -1,0 +1,98 @@
+/*
+* Vieb - Vim Inspired Electron Browser
+* Copyright (C) 2020-2025 Jelmer van Arnhem
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+/* colors */
+:root {
+    /* general */
+    --bg: #eee;
+    --fg: #333;
+    --tab-background: #ddd;
+    --tab-suspended: #777;
+    --visible-tab: #fff;
+    --tab-crashed: #faa;
+    --mode-normal-fg: #333;
+    --mode-insert-fg: #0c0;
+    --mode-explore-fg: #0cc;
+    --mode-search-fg: #fb0;
+    --url-default: #ddd;
+    --url-search: #f80;
+    --url-searchwords: #f5f;
+    --url-url: #08f;
+    --url-suggest: #0c0;
+    --url-file: #fb0;
+    --suggestions-border: #eee;
+    --suggestions-bg: #ddd;
+    --suggestions-selected: #fff;
+    --suggestions-url: #08f;
+    --suggestions-file: #f80;
+    --notification-border: #aaa;
+    --notification-date: #777;
+    --notification-permission: #777;
+    --notification-error: #f33;
+    --notification-warning: #f80;
+    --notification-info: #08f;
+    --notification-success: #0c0;
+    /* special pages */
+    --link-color: #08f;
+    --link-underline: #0df;
+    --scrollbar-bg: #fff;
+    --scrollbar-thumb: #aaa7;
+    --button-disabled: #777;
+    --code-fg: #000;
+    --code-bg: #fff;
+    --special-page-element-bg: #ddd;
+    --special-page-element-border: #aaa;
+    --input-unfocused: #aaa;
+    --input-focused: #666;
+    --download-progress-fg: #fff;
+    --download-progress-bg: #eee;
+    --helppage-countable: #0c0;
+    /* sourceviewer */
+    --syntax-keyword: #d45;
+    --syntax-entity: #74c;
+    --syntax-constant: #06c;
+    --syntax-string: #036;
+    --syntax-variable: #e60;
+    --syntax-comment: #777;
+    --syntax-entity-tag: #284;
+    --syntax-markup-heading: #06c;
+    --syntax-markup-list: #760;
+    --syntax-markup-emphasis: #233;
+    --syntax-markup-addition-fg: #284;
+    --syntax-markup-addition-bg: #efe;
+    --syntax-markup-deletion-fg: #b22;
+    --syntax-markup-deletion-bg: #fee;
+}
+
+/* general */
+#tabs .status {filter: invert(.4);}
+
+/* special pages */
+#app #pointer, #cookiespage img, #downloadspage img, #historypage img {filter: invert(1);}
+.specialpage a::after {filter: invert(1);}
+#helppage .cheatsheet {filter: none;}
+#historypage img.favicon {filter: none;}
+
+/* general */
+#app {flex-direction: column-reverse;}
+#url-hover {bottom: 4em;}
+#suggest-dropdown {top: auto;bottom: .1em;flex-direction: column-reverse;}
+#mode-suggestions {top: auto;bottom: 1.9em;flex-direction: column-reverse;}
+/* hidden bars */
+#app.tabshidden #url-hover, #app.navigationhidden #url-hover {bottom: 2em;}
+#app.tabshidden.navigationhidden #url-hover {bottom: 0;}
+#app.navigationhidden #suggest-dropdown {top: auto;bottom: .1em;}

--- a/app/colors/light-numberedtabs.css
+++ b/app/colors/light-numberedtabs.css
@@ -1,0 +1,94 @@
+/*
+* Vieb - Vim Inspired Electron Browser
+* Copyright (C) 2022-2025 Jelmer van Arnhem
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+/* colors */
+:root {
+    /* general */
+    --bg: #eee;
+    --fg: #333;
+    --tab-background: #ddd;
+    --tab-suspended: #777;
+    --visible-tab: #fff;
+    --tab-crashed: #faa;
+    --mode-normal-fg: #333;
+    --mode-insert-fg: #0c0;
+    --mode-explore-fg: #0cc;
+    --mode-search-fg: #fb0;
+    --url-default: #ddd;
+    --url-search: #f80;
+    --url-searchwords: #f5f;
+    --url-url: #08f;
+    --url-suggest: #0c0;
+    --url-file: #fb0;
+    --suggestions-border: #eee;
+    --suggestions-bg: #ddd;
+    --suggestions-selected: #fff;
+    --suggestions-url: #08f;
+    --suggestions-file: #f80;
+    --notification-border: #aaa;
+    --notification-date: #777;
+    --notification-permission: #777;
+    --notification-error: #f33;
+    --notification-warning: #f80;
+    --notification-info: #08f;
+    --notification-success: #0c0;
+    /* special pages */
+    --link-color: #08f;
+    --link-underline: #0df;
+    --scrollbar-bg: #fff;
+    --scrollbar-thumb: #aaa7;
+    --button-disabled: #777;
+    --code-fg: #000;
+    --code-bg: #fff;
+    --special-page-element-bg: #ddd;
+    --special-page-element-border: #aaa;
+    --input-unfocused: #aaa;
+    --input-focused: #666;
+    --download-progress-fg: #fff;
+    --download-progress-bg: #eee;
+    --helppage-countable: #0c0;
+    /* sourceviewer */
+    --syntax-keyword: #d45;
+    --syntax-entity: #74c;
+    --syntax-constant: #06c;
+    --syntax-string: #036;
+    --syntax-variable: #e60;
+    --syntax-comment: #777;
+    --syntax-entity-tag: #284;
+    --syntax-markup-heading: #06c;
+    --syntax-markup-list: #760;
+    --syntax-markup-emphasis: #233;
+    --syntax-markup-addition-fg: #284;
+    --syntax-markup-addition-bg: #efe;
+    --syntax-markup-deletion-fg: #b22;
+    --syntax-markup-deletion-bg: #fee;
+}
+
+/* general */
+#tabs .status {filter: invert(.4);}
+
+/* special pages */
+#app #pointer, #cookiespage img, #downloadspage img, #historypage img {filter: invert(1);}
+.specialpage a::after {filter: invert(1);}
+#helppage .cheatsheet {filter: none;}
+#historypage img.favicon {filter: none;}
+
+/* numbered tabs */
+#tabs, #navbar {counter-reset: tab-counter -1;}
+#tabs > ::before {counter-increment: tab-counter 1;content: counter(tab-counter) ". ";margin: auto 0;}
+#tabs [media-playing]::before {margin: 0 !important;}
+#tabs .pinned {min-width: 3em !important;}

--- a/app/colors/light-verticaltabs.css
+++ b/app/colors/light-verticaltabs.css
@@ -1,0 +1,89 @@
+/*
+* Vieb - Vim Inspired Electron Browser
+* Copyright (C) 2020-2025 Jelmer van Arnhem
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+/* colors */
+:root {
+    /* general */
+    --bg: #eee;
+    --fg: #333;
+    --tab-background: #ddd;
+    --tab-suspended: #777;
+    --visible-tab: #fff;
+    --tab-crashed: #faa;
+    --mode-normal-fg: #333;
+    --mode-insert-fg: #0c0;
+    --mode-explore-fg: #0cc;
+    --mode-search-fg: #fb0;
+    --url-default: #ddd;
+    --url-search: #f80;
+    --url-searchwords: #f5f;
+    --url-url: #08f;
+    --url-suggest: #0c0;
+    --url-file: #fb0;
+    --suggestions-border: #eee;
+    --suggestions-bg: #ddd;
+    --suggestions-selected: #fff;
+    --suggestions-url: #08f;
+    --suggestions-file: #f80;
+    --notification-border: #aaa;
+    --notification-date: #777;
+    --notification-permission: #777;
+    --notification-error: #f33;
+    --notification-warning: #f80;
+    --notification-info: #08f;
+    --notification-success: #0c0;
+    /* special pages */
+    --link-color: #08f;
+    --link-underline: #0df;
+    --scrollbar-bg: #fff;
+    --scrollbar-thumb: #aaa7;
+    --button-disabled: #777;
+    --code-fg: #000;
+    --code-bg: #fff;
+    --special-page-element-bg: #ddd;
+    --special-page-element-border: #aaa;
+    --input-unfocused: #aaa;
+    --input-focused: #666;
+    --download-progress-fg: #fff;
+    --download-progress-bg: #eee;
+    --helppage-countable: #0c0;
+    /* sourceviewer */
+    --syntax-keyword: #d45;
+    --syntax-entity: #74c;
+    --syntax-constant: #06c;
+    --syntax-string: #036;
+    --syntax-variable: #e60;
+    --syntax-comment: #777;
+    --syntax-entity-tag: #284;
+    --syntax-markup-heading: #06c;
+    --syntax-markup-list: #760;
+    --syntax-markup-emphasis: #233;
+    --syntax-markup-addition-fg: #284;
+    --syntax-markup-addition-bg: #efe;
+    --syntax-markup-deletion-fg: #b22;
+    --syntax-markup-deletion-bg: #fee;
+}
+
+/* vertical tabs */
+#tabs {overflow-x: hidden;overflow-y: auto;position: absolute;left: 0;width: 15vw;max-height: calc(100vh - 2em);top: 2em;flex-wrap: wrap;}
+#tabs > span {min-height: 1.9em;max-height: 1.9em;min-width: 14vw !important;width: 15vw;}
+#page-container {height: calc(100vh - 2em);position: absolute;top: 2em;left: 15vw;width: 85vw;}
+#app.fullscreen #page-container {height: 100vh;width: 100vw;top: 0;left: 0;}
+#app.tabshidden #page-container {width: 100vw;left: 0;}
+#app.navigationhidden #page-container {height: 100vh;top: 0;}
+#app.navigationhidden #tabs {top: 0;max-height: 100vh;}
+#tabs::-webkit-scrollbar {width: .2em;height: auto;}

--- a/app/colors/light-verticaltabsright.css
+++ b/app/colors/light-verticaltabsright.css
@@ -1,0 +1,89 @@
+/*
+* Vieb - Vim Inspired Electron Browser
+* Copyright (C) 2020-2025 Jelmer van Arnhem
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+/* colors */
+:root {
+    /* general */
+    --bg: #eee;
+    --fg: #333;
+    --tab-background: #ddd;
+    --tab-suspended: #777;
+    --visible-tab: #fff;
+    --tab-crashed: #faa;
+    --mode-normal-fg: #333;
+    --mode-insert-fg: #0c0;
+    --mode-explore-fg: #0cc;
+    --mode-search-fg: #fb0;
+    --url-default: #ddd;
+    --url-search: #f80;
+    --url-searchwords: #f5f;
+    --url-url: #08f;
+    --url-suggest: #0c0;
+    --url-file: #fb0;
+    --suggestions-border: #eee;
+    --suggestions-bg: #ddd;
+    --suggestions-selected: #fff;
+    --suggestions-url: #08f;
+    --suggestions-file: #f80;
+    --notification-border: #aaa;
+    --notification-date: #777;
+    --notification-permission: #777;
+    --notification-error: #f33;
+    --notification-warning: #f80;
+    --notification-info: #08f;
+    --notification-success: #0c0;
+    /* special pages */
+    --link-color: #08f;
+    --link-underline: #0df;
+    --scrollbar-bg: #fff;
+    --scrollbar-thumb: #aaa7;
+    --button-disabled: #777;
+    --code-fg: #000;
+    --code-bg: #fff;
+    --special-page-element-bg: #ddd;
+    --special-page-element-border: #aaa;
+    --input-unfocused: #aaa;
+    --input-focused: #666;
+    --download-progress-fg: #fff;
+    --download-progress-bg: #eee;
+    --helppage-countable: #0c0;
+    /* sourceviewer */
+    --syntax-keyword: #d45;
+    --syntax-entity: #74c;
+    --syntax-constant: #06c;
+    --syntax-string: #036;
+    --syntax-variable: #e60;
+    --syntax-comment: #777;
+    --syntax-entity-tag: #284;
+    --syntax-markup-heading: #06c;
+    --syntax-markup-list: #760;
+    --syntax-markup-emphasis: #233;
+    --syntax-markup-addition-fg: #284;
+    --syntax-markup-addition-bg: #efe;
+    --syntax-markup-deletion-fg: #b22;
+    --syntax-markup-deletion-bg: #fee;
+}
+
+/* vertical tabs right */
+#tabs {overflow-x: hidden;overflow-y: auto;position: absolute;right: 0;width: 15vw;max-height: calc(100vh - 2em);top: 2em;flex-wrap: wrap;}
+#tabs > span {min-height: 1.9em;max-height: 1.9em;min-width: 14vw !important;width: 15vw;}
+#page-container {height: calc(100vh - 2em);position: absolute;top: 2em;right: 15vw;width: 85vw;}
+#app.fullscreen #page-container {height: 100vh;width: 100vw;top: 0;left: 0;}
+#app.tabshidden #page-container {width: 100vw;right: 0;}
+#app.navigationhidden #page-container {height: 100vh;top: 0;}
+#app.navigationhidden #tabs {top: 0;max-height: 100vh;}
+#tabs::-webkit-scrollbar {width: .2em;height: auto;}

--- a/app/colors/verticaltabs.css
+++ b/app/colors/verticaltabs.css
@@ -15,7 +15,6 @@
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-
 #tabs {overflow-x: hidden;overflow-y: auto;position: absolute;left: 0;width: 15vw;max-height: calc(100vh - 2em);top: 2em;flex-wrap: wrap;}
 #tabs > span {min-height: 1.9em;max-height: 1.9em;min-width: 14vw !important;width: 15vw;}
 #page-container {height: calc(100vh - 2em);position: absolute;top: 2em;left: 15vw;width: 85vw;}

--- a/app/colors/verticaltabsright.css
+++ b/app/colors/verticaltabsright.css
@@ -15,7 +15,6 @@
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-
 #tabs {overflow-x: hidden;overflow-y: auto;position: absolute;right: 0;width: 15vw;max-height: calc(100vh - 2em);top: 2em;flex-wrap: wrap;}
 #tabs > span {min-height: 1.9em;max-height: 1.9em;min-width: 14vw !important;width: 15vw;}
 #page-container {height: calc(100vh - 2em);position: absolute;top: 2em;right: 15vw;width: 85vw;}

--- a/app/renderer/command.js
+++ b/app/renderer/command.js
@@ -1017,7 +1017,8 @@ const quit = (src, range) => {
     }
 }
 
-let currentscheme = "default"
+let defaultscheme = "default"
+let currentscheme = defaultscheme
 
 /**
  * Set the colorscheme by name or log the current one if no name provided.
@@ -1054,7 +1055,7 @@ const colorscheme = (src, name = null, trailingArgs = null) => {
         })
         return
     }
-    if (name === "default") {
+    if (name === defaultscheme) {
         css = ""
     }
     if (!document.getElementById("custom-styling")) {


### PR DESCRIPTION
Since recently `set nativetheme=system` was revived, and with it becoming the default in 13.0.0, I thought it would make sense to also dynamically adjust Vieb's own colorscheme based on system preference.
I did a naive search and replace for `default.css` to `dark.css` I doubt it is desireable to leave it as is, but it works as far as I tested.
This is a draft mainly because I want feedback about how to handle `default.css` and `dark.css` and ask if perhaps it's best to add css importing instead of repeating the light colorscheme everywhere, I didn't make it into  an issue  because I also want it to be available to anyone who wants to try it out.