### PR TITLE
Fix incorrect base URL for EasyList downloads in blocklists list.json

### DIFF
--- a/app/blocklists/list.json
+++ b/app/blocklists/list.json
@@ -1,6 +1,6 @@
 {
-    "easylist": "https://easylist-downloads.adblockplus.org/easylist.txt",
-    "easyprivacy": "https://easylist-downloads.adblockplus.org/easyprivacy.txt",
+    "easylist": "https://easylist.to/easylist/easylist.txt",
+    "easyprivacy": "https://easylist.to/easylist/easyprivacy.txt",
     "ublockfilters": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt",
     "ublockfilters2020": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2020.txt",
     "ublockfilters2021": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2021.txt",


### PR DESCRIPTION
The blocklists list.json uses adblockplus.org URLs for easylist and easyprivacy. However, the README in the blocklists folder notes that these URLs are broken due to easylist website issues (https://github.com/easylist/easylist/issues/13389). This fix updates the URLs to point to the currently working mirrors on easylist.to. This is a functional improvement to ensure adblock filtering works out of the box for users who choose 'update' mode instead of 'static'.